### PR TITLE
Add task waiter

### DIFF
--- a/lib/ecs_deploy/task_definition.rb
+++ b/lib/ecs_deploy/task_definition.rb
@@ -52,6 +52,12 @@ module EcsDeploy
             raise "#{f.arn}: #{f.reason}"
           end
         end
+
+        if info[:wait_stop]
+          client.wait_until(:tasks_running, cluster: info[:cluster], task_definition: [@task_definition_name])
+          client.wait_until(:tasks_stopped, cluster: info[:cluster], task_definition: [@task_definition_name])
+        end
+
         EcsDeploy.logger.info "run task [#{@task_definition_name} #{info.inspect}] [#{region}] [#{Paint['OK', :green]}]"
       end
     end

--- a/lib/ecs_deploy/task_definition.rb
+++ b/lib/ecs_deploy/task_definition.rb
@@ -54,8 +54,8 @@ module EcsDeploy
         end
 
         if info[:wait_stop]
-          client.wait_until(:tasks_running, cluster: info[:cluster], task_definition: [@task_definition_name])
-          client.wait_until(:tasks_stopped, cluster: info[:cluster], task_definition: [@task_definition_name])
+          client.wait_until(:tasks_running, cluster: info[:cluster], tasks: resp.tasks.map { |t| t.task_arn })
+          client.wait_until(:tasks_stopped, cluster: info[:cluster], tasks: resp.tasks.map { |t| t.task_arn })
         end
 
         EcsDeploy.logger.info "run task [#{@task_definition_name} #{info.inspect}] [#{region}] [#{Paint['OK', :green]}]"

--- a/lib/ecs_deploy/task_definition.rb
+++ b/lib/ecs_deploy/task_definition.rb
@@ -53,9 +53,21 @@ module EcsDeploy
           end
         end
 
-        if info[:wait_stop]
+        wait_targets = Array(info[:wait_stop])
+        unless wait_targets.empty?
           client.wait_until(:tasks_running, cluster: info[:cluster], tasks: resp.tasks.map { |t| t.task_arn })
           client.wait_until(:tasks_stopped, cluster: info[:cluster], tasks: resp.tasks.map { |t| t.task_arn })
+
+          resp = client.describe_tasks(cluster: info[:cluster], tasks: resp.tasks.map { |t| t.task_arn })
+          resp.tasks.each do |t|
+            t.containers.each do |c|
+              next unless wait_targets.include?(c.name)
+
+              unless c.exit_code.zero?
+                raise "Task has errors: #{c.reason}"
+              end
+            end
+          end
         end
 
         EcsDeploy.logger.info "run task [#{@task_definition_name} #{info.inspect}] [#{region}] [#{Paint['OK', :green]}]"


### PR DESCRIPTION
デプロイ時にタスクを実行した時(db:migrate等)、終了を待たずに先に進んでしまうと、サービスコンテナがmigrate前に起動してARのカラム状態が更新されない可能性があるため、ワンタイムタスクの終了を待ち受けられるようにしました。
レビューお願いします。 @tomykaira @threetreeslight @taiSon 