### PR TITLE
Fix missing desired_count for backend services

### DIFF
--- a/lib/ecs_deploy/service.rb
+++ b/lib/ecs_deploy/service.rb
@@ -40,11 +40,13 @@ module EcsDeploy
         deployment_configuration: @deployment_configuration,
       }
       if res.services.empty?
-        service_options.merge!({service_name: @service_name})
+        service_options.merge!({
+          service_name: @service_name,
+          desired_count: @desired_count.to_i,
+        })
         if @elb_name
           service_options.merge!({
             role: EcsDeploy.config.ecs_service_role,
-            desired_count: @desired_count.to_i,
             load_balancers: [
               {
                 load_balancer_name: @elb_name,


### PR DESCRIPTION
:desired_count is reqired for all services to create, but it was not specified for services without ELB.

@joker1007 plz review.