### PR TITLE
Update README for scheduled_min_task_count

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ services:
     step: 1
     idle_time: 240
     max_task_count: [10, 25]
+    scheduled_min_task_count:
+      - {from: "1:45", to: "4:30", count: 8}
     cooldown_time_for_reach_max: 600
     min_task_count: 0
     upscale_triggers:


### PR DESCRIPTION
[scheduled_min_task_count](https://github.com/reproio/ecs_deploy/pull/7) の設定に関する記載が README になかったので追加します。