### PR TITLE
Improve passing of region to AWS API

### DIFF
--- a/lib/ecs_deploy/service.rb
+++ b/lib/ecs_deploy/service.rb
@@ -18,10 +18,12 @@ module EcsDeploy
       @desired_count = desired_count
       @deployment_configuration = deployment_configuration
       @revision = revision
-      @region = region || EcsDeploy.config.default_region || ENV["AWS_DEFAULT_REGION"]
+      @region = region || EcsDeploy.config.default_region
+      options = {}
+      options[:region] = @region if @region
       @response = nil
 
-      @client = Aws::ECS::Client.new(region: @region)
+      @client = Aws::ECS::Client.new(options)
     end
 
     def current_task_definition_arn

--- a/lib/ecs_deploy/task_definition.rb
+++ b/lib/ecs_deploy/task_definition.rb
@@ -16,8 +16,9 @@ module EcsDeploy
     )
       @task_definition_name = task_definition_name
       @task_role_arn        = task_role_arn
-      @region = region || EcsDeploy.config.default_region || ENV["AWS_DEFAULT_REGION"]
-
+      @region = region || EcsDeploy.config.default_region
+      options = {}
+      options[:region] = @region if @region
       @container_definitions = container_definitions.map do |cd|
         if cd[:docker_labels]
           cd[:docker_labels] = cd[:docker_labels].map { |k, v| [k.to_s, v] }.to_h
@@ -29,7 +30,7 @@ module EcsDeploy
       end
       @volumes = volumes
 
-      @client = Aws::ECS::Client.new(region: @region)
+      @client = Aws::ECS::Client.new(options)
     end
 
     def recent_task_definition_arns


### PR DESCRIPTION
The region param should be optional and had a wrong default anyways. The AWS CLI for Ruby is smart, and will fetch `ENV['AWS_REGION']` automatically, cf https://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html