### PR TITLE
filter inactive services

### DIFF
--- a/lib/ecs_deploy/service.rb
+++ b/lib/ecs_deploy/service.rb
@@ -36,7 +36,7 @@ module EcsDeploy
         task_definition: task_definition_name_with_revision,
         deployment_configuration: @deployment_configuration,
       }
-      if res.services.empty?
+      if res.services.select{ |s| s.status == 'ACTIVE' }.empty?
         service_options.merge!({
           service_name: @service_name,
           desired_count: @desired_count.to_i,


### PR DESCRIPTION
Once you call deleteService API, its status become `INACTIVE` instead of being deleted. Inactive service cannot be updated but service which has the exactly same name can be newly created.

- http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_UpdateService.html

This PR adds check whether the specified services is ACTIVE or not. If the status is not ACTIVE or service does not exist, try to create new one. Otherwise, the service will be updated. 

