### PR TITLE
Support ScheduledTask

### DIFF
--- a/ecs_deploy.gemspec
+++ b/ecs_deploy.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "aws-sdk", "~> 2.4"
+  spec.add_runtime_dependency "aws-sdk", "~> 2.9"
   spec.add_runtime_dependency "terminal-table"
   spec.add_runtime_dependency "paint"
 

--- a/lib/ecs_deploy.rb
+++ b/lib/ecs_deploy.rb
@@ -27,3 +27,4 @@ end
 
 require "ecs_deploy/task_definition"
 require "ecs_deploy/service"
+require "ecs_deploy/scheduled_task"

--- a/lib/ecs_deploy/capistrano.rb
+++ b/lib/ecs_deploy/capistrano.rb
@@ -43,6 +43,31 @@ namespace :ecs do
     end
   end
 
+  task deploy_scheduled_task: [:configure, :register_task_definition] do
+    if fetch(:ecs_tasks)
+      regions = Array(fetch(:ecs_region))
+      regions = [nil] if regions.empty?
+      regions.each do |r|
+        fetch(:ecs_scheduled_tasks).each do |t|
+          scheduled_task = EcsDeploy::ScheduledTask.new(
+            region: r,
+            cluster: t[:cluster],
+            rule_name: t[:rule_name],
+            schedule_expression: t[:schedule_expression],
+            enabled: t[:enabled] != false,
+            description: t[:description],
+            target_id: t[:target_id],
+            task_definition_name: t[:task_definition_name],
+            revision: t[:revision],
+            task_count: t[:task_count],
+            role_arn: t[:role_arn],
+          )
+          scheduled_task.deploy
+        end
+      end
+    end
+  end
+
   task deploy: [:configure, :register_task_definition] do
     if fetch(:ecs_services)
       regions = Array(fetch(:ecs_region))

--- a/lib/ecs_deploy/scheduled_task.rb
+++ b/lib/ecs_deploy/scheduled_task.rb
@@ -1,0 +1,80 @@
+require 'timeout'
+
+module EcsDeploy
+  class ScheduledTask
+    attr_reader :cluster, :region, :schedule_rule_name
+
+    def initialize(
+      cluster:, rule_name:, schedule_expression:, enabled: true, description: nil, target_id: nil,
+      task_definition_name:, revision: nil, task_count: nil, role_arn:,
+      region: nil
+    )
+      @cluster = cluster
+      @rule_name = rule_name
+      @schedule_expression = schedule_expression
+      @enabled = enabled
+      @description = description
+      @target_id = target_id || task_definition_name
+      @task_definition_name = task_definition_name
+      @task_count = task_count || 1
+      @revision = revision
+      @role_arn = role_arn
+      @region = region || EcsDeploy.config.default_region || ENV["AWS_DEFAULT_REGION"]
+
+      @client = Aws::ECS::Client.new(region: @region)
+      @cloud_watch_events = Aws::CloudWatchEvents::Client.new(region: @region)
+    end
+
+    def deploy
+      put_rule
+      put_targets
+    end
+
+    private
+
+    def cluster_arn
+      cl = @client.describe_clusters(clusters: [@cluster]).clusters[0]
+      if cl
+        cl.cluster_arn
+      end
+    end
+
+    def task_definition_arn
+      suffix = @revision ? ":#{@revision}" : ""
+      name = "#{@task_definition_name}#{suffix}"
+      @client.describe_task_definition(task_definition: name).task_definition.task_definition_arn
+    end
+
+    def put_rule
+      res = @cloud_watch_events.put_rule(
+        name: @rule_name,
+        schedule_expression: @schedule_expression,
+        state: @enabled ? "ENABLED" : "DISABLED",
+        description: @description,
+      )
+      EcsDeploy.logger.info "create cloudwatch event rule [#{res.rule_arn}] [#{@region}] [#{Paint['OK', :green]}]"
+    end
+
+    def put_targets
+      res = @cloud_watch_events.put_targets(
+        rule: @rule_name,
+        targets: [
+          {
+            id: @target_id,
+            arn: cluster_arn,
+            role_arn: @role_arn,
+            ecs_parameters: {
+              task_definition_arn: task_definition_arn,
+              task_count: @task_count,
+            },
+          }
+        ]
+      )
+      if res.failed_entry_count.zero?
+        EcsDeploy.logger.info "create cloudwatch event target [#{@target_id}] [#{@region}] [#{Paint['OK', :green]}]"
+      else
+        raise "failed to create cloudwatch event target [#{@target_id}] [#{@region}]"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Support Scheduled Task deployment and implements capistrano task.


example.

```ruby
set :ecs_scheduled_tasks, [
  {
    cluster: "repro-development",
    rule_name: "scheduled-task-test",
    schedule_expression: "cron(0/5 * * * ? *)",
    task_definition_name: "scheduled-task-test-dev_staging",
    role_arn: "arn:aws:iam::113190696079:role/ecsEventsRole",
  }
]
```

```sh
cap dev_staging ecs:deploy_scheduled_task
```