### PR TITLE
Enable to use registerd task_definition info

### DIFF
--- a/lib/ecs_deploy/capistrano.rb
+++ b/lib/ecs_deploy/capistrano.rb
@@ -20,10 +20,9 @@ namespace :ecs do
   task register_task_definition: [:configure] do
     if fetch(:ecs_tasks)
       regions = Array(fetch(:ecs_region))
-      regions = [nil] if regions.empty?
+      regions = [EcsDeploy.config.default_region || ENV["AWS_DEFAULT_REGION"]] if regions.empty?
       ecs_registered_tasks = {}
       regions.each do |r|
-        region = r || EcsDeploy.config.default_region || ENV["AWS_DEFAULT_REGION"]
         ecs_registered_tasks[region] = {}
         fetch(:ecs_tasks).each do |t|
           task_definition = EcsDeploy::TaskDefinition.new(
@@ -42,7 +41,7 @@ namespace :ecs do
           unless executions.empty?
             warn "`executions` config is deprecated. I will remove this in near future"
           end
-          executions.to_a.each do |exec|
+          executions.each do |exec|
             exec[:cluster] ||= fetch(:ecs_default_cluster)
             task_definition.run(exec)
           end

--- a/lib/ecs_deploy/capistrano.rb
+++ b/lib/ecs_deploy/capistrano.rb
@@ -21,10 +21,13 @@ namespace :ecs do
     if fetch(:ecs_tasks)
       regions = Array(fetch(:ecs_region))
       regions = [nil] if regions.empty?
+      ecs_registered_tasks = {}
       regions.each do |r|
+        region = r || EcsDeploy.config.default_region || ENV["AWS_DEFAULT_REGION"]
+        ecs_registered_tasks[region] = {}
         fetch(:ecs_tasks).each do |t|
           task_definition = EcsDeploy::TaskDefinition.new(
-            region: r,
+            region: region,
             task_definition_name: t[:name],
             container_definitions: t[:container_definitions],
             task_role_arn: t[:task_role_arn],
@@ -32,14 +35,21 @@ namespace :ecs do
             network_mode: t[:network_mode],
             placement_constraints: t[:placement_constraints],
           )
-          task_definition.register
+          result = task_definition.register
+          ecs_registered_tasks[region][t[:name]] = result
 
-          t[:executions].to_a.each do |exec|
+          executions = t[:executions].to_a
+          unless executions.empty?
+            warn "`executions` config is deprecated. I will remove this in near future"
+          end
+          executions.to_a.each do |exec|
             exec[:cluster] ||= fetch(:ecs_default_cluster)
             task_definition.run(exec)
           end
         end
       end
+
+      set :ecs_registered_tasks, ecs_registered_tasks
     end
   end
 

--- a/lib/ecs_deploy/task_definition.rb
+++ b/lib/ecs_deploy/task_definition.rb
@@ -45,7 +45,7 @@ module EcsDeploy
     end
 
     def register
-      @client.register_task_definition({
+      res = @client.register_task_definition({
         family: @task_definition_name,
         network_mode: @network_mode,
         container_definitions: @container_definitions,
@@ -54,6 +54,7 @@ module EcsDeploy
         task_role_arn: @task_role_arn,
       })
       EcsDeploy.logger.info "register task definition [#{@task_definition_name}] [#{@region}] [#{Paint['OK', :green]}]"
+      res.task_definition
     end
 
     def run(info)


### PR DESCRIPTION
after `:register_task_definition`, `set(:ecs_registered_tasks)`.

Usage:
```ruby
set :ecs_executions_before_deploy, -> do
  repro_rake = fetch(:ecs_registered_tasks)["ap-northeast-1"]["repro-rake"]
  [
    {
      cluster: "repro-development",
      region: "ap-northeast-1",
      task_definition: {
        task_definition_name: "#{repro_rake.family}:#{repro_rake.revision}",
        main_container_name: "repro-rake"
      },
      command: ["db:ridgepole:apply"],
    }
  ]
end
```