### PR TITLE
Fix a local variable name

### DIFF
--- a/lib/ecs_deploy/capistrano.rb
+++ b/lib/ecs_deploy/capistrano.rb
@@ -22,7 +22,7 @@ namespace :ecs do
       regions = Array(fetch(:ecs_region))
       regions = [EcsDeploy.config.default_region || ENV["AWS_DEFAULT_REGION"]] if regions.empty?
       ecs_registered_tasks = {}
-      regions.each do |r|
+      regions.each do |region|
         ecs_registered_tasks[region] = {}
         fetch(:ecs_tasks).each do |t|
           task_definition = EcsDeploy::TaskDefinition.new(


### PR DESCRIPTION
This PR resolves errors like below:

```
NameError: undefined local variable or method `region' for main:Object
Did you mean?  regions
/path/to/vendor/bundle/ruby/2.4.0/bundler/gems/ecs_deploy-842fdfc8f24d/lib/ecs_deploy/capistrano.rb:26:in `block (3 levels) in <top (required)>'
/path/to/vendor/bundle/ruby/2.4.0/bundler/gems/ecs_deploy-842fdfc8f24d/lib/ecs_deploy/capistrano.rb:25:in `each'
/path/to/vendor/bundle/ruby/2.4.0/bundler/gems/ecs_deploy-842fdfc8f24d/lib/ecs_deploy/capistrano.rb:25:in `block (2 levels) in <top (required)>'
/path/to/vendor/bundle/ruby/2.4.0/gems/rake-12.0.0/lib/rake/task.rb:250:in `block in execute'
/path/to/vendor/bundle/ruby/2.4.0/gems/rake-12.0.0/lib/rake/task.rb:250:in `each'
/path/to/vendor/bundle/ruby/2.4.0/gems/rake-12.0.0/lib/rake/task.rb:250:in `execute'
(snip)
```