### PR TITLE
Support container overrides in scheduled tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ set :ecs_scheduled_tasks, [
     task_count: 2, # Default 1
     revision: 12, # Optional
     role_arn: "TaskRoleArn", # Optional
+    container_overrides: [ # Optional
+      name: "myapp-main",
+      command: ["ls"],
+    ]
   }
 ]
 

--- a/lib/ecs_deploy/capistrano.rb
+++ b/lib/ecs_deploy/capistrano.rb
@@ -61,6 +61,7 @@ namespace :ecs do
             revision: t[:revision],
             task_count: t[:task_count],
             role_arn: t[:role_arn],
+            container_overrides: t[:container_overrides],
           )
           scheduled_task.deploy
         end


### PR DESCRIPTION
CloudWatch Events allow us to override container definitions by specifying `input` parameter and I want to use the feature.
cf. http://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_PutTargets.html
