### PR TITLE
Fix deploy error when has no scheduled tasks

### DIFF
--- a/lib/ecs_deploy/capistrano.rb
+++ b/lib/ecs_deploy/capistrano.rb
@@ -44,7 +44,7 @@ namespace :ecs do
   end
 
   task deploy_scheduled_task: [:configure, :register_task_definition] do
-    if fetch(:ecs_tasks)
+    if fetch(:ecs_scheduled_tasks)
       regions = Array(fetch(:ecs_region))
       regions = [nil] if regions.empty?
       regions.each do |r|


### PR DESCRIPTION
if `ecs_scheduled_tasks` is no set, then deploy failed.

```
...

** Invoke after_release:add_ecs_scheduled_tasks (first_time)
** Execute after_release:add_ecs_scheduled_tasks
** Execute ecs:deploy_scheduled_task
cap aborted!
NoMethodError: undefined method `each' for nil:NilClass
/Users/kei_q/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/bundler/gems/ecs_deploy-bf5d8e33ab90/lib/ecs_deploy/capistrano.rb:51:in `block (3 levels) in <top (required)>'
/Users/kei_q/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/bundler/gems/ecs_deploy-bf5d8e33ab90/lib/ecs_deploy/capistrano.rb:50:in `each'
/Users/kei_q/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/bundler/gems/ecs_deploy-bf5d8e33ab90/lib/ecs_deploy/capistrano.rb:50:in `block (2 levels) in <top (required)>'
/Users/kei_q/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/task.rb:250:in `block in execute'
/Users/kei_q/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/task.rb:250:in `each'
/Users/kei_q/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/task.rb:250:in `execute'

...
```