### PR TITLE
Remove unused method calls

### DIFF
--- a/lib/ecs_deploy/auto_scaler.rb
+++ b/lib/ecs_deploy/auto_scaler.rb
@@ -290,7 +290,6 @@ module EcsDeploy
         end
       rescue => e
         AutoScaler.error_logger.error(e)
-        clear_client
       end
     end
 


### PR DESCRIPTION
`clear_client` was removed in e1f8d67.