### PR TITLE
Adjust `wait_until` timeout of ECS service_stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ set :ecs_default_cluster, "ecs-cluster-name"
 set :ecs_region, %w(ap-northeast-1) # optional, if nil, use environment variable
 set :ecs_service_role, "customEcsServiceRole" # default: ecsServiceRole
 set :ecs_deploy_wait_timeout, 600 # default: 300
-set :ecs_service_wait_until_max_attempts, 40 # optional
-set :ecs_service_wait_until_delay, 15 # optional
+set :ecs_wait_until_services_stable_max_attempts, 40 # optional
+set :ecs_wait_until_services_stable_delay, 15 # optional
 
 set :ecs_tasks, [
   {

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ set :ecs_default_cluster, "ecs-cluster-name"
 set :ecs_region, %w(ap-northeast-1) # optional, if nil, use environment variable
 set :ecs_service_role, "customEcsServiceRole" # default: ecsServiceRole
 set :ecs_deploy_wait_timeout, 600 # default: 300
+set :ecs_service_wait_until_max_attempts, 40 # optional
+set :ecs_service_wait_until_delay, 15 # optional
 
 set :ecs_tasks, [
   {

--- a/lib/ecs_deploy/capistrano.rb
+++ b/lib/ecs_deploy/capistrano.rb
@@ -7,8 +7,8 @@ namespace :ecs do
       c.deploy_wait_timeout = fetch(:ecs_deploy_wait_timeout) if fetch(:ecs_deploy_wait_timeout)
       c.ecs_service_role = fetch(:ecs_service_role) if fetch(:ecs_service_role)
       c.default_region = Array(fetch(:ecs_region))[0] if fetch(:ecs_region)
-      c.ecs_service_wait_until_max_attempts = fetch(:ecs_service_wait_until_max_attempts) if fetch(:ecs_service_wait_until_max_attempts)
-      c.ecs_service_wait_until_delay = fetch(:ecs_service_wait_until_delay) if fetch(:ecs_service_wait_until_delay)
+      c.ecs_wait_until_services_stable_max_attempts = fetch(:ecs_wait_until_services_stable_max_attempts) if fetch(:ecs_wait_until_services_stable_max_attempts)
+      c.ecs_wait_until_services_stable_delay = fetch(:ecs_wait_until_services_stable_delay) if fetch(:ecs_wait_until_services_stable_delay)
     end
 
     if ENV["TARGET_CLUSTER"]

--- a/lib/ecs_deploy/capistrano.rb
+++ b/lib/ecs_deploy/capistrano.rb
@@ -7,6 +7,8 @@ namespace :ecs do
       c.deploy_wait_timeout = fetch(:ecs_deploy_wait_timeout) if fetch(:ecs_deploy_wait_timeout)
       c.ecs_service_role = fetch(:ecs_service_role) if fetch(:ecs_service_role)
       c.default_region = Array(fetch(:ecs_region))[0] if fetch(:ecs_region)
+      c.ecs_service_wait_until_max_attempts = fetch(:ecs_service_wait_until_max_attempts) if fetch(:ecs_service_wait_until_max_attempts)
+      c.ecs_service_wait_until_delay = fetch(:ecs_service_wait_until_delay) if fetch(:ecs_service_wait_until_delay)
     end
 
     if ENV["TARGET_CLUSTER"]

--- a/lib/ecs_deploy/configuration.rb
+++ b/lib/ecs_deploy/configuration.rb
@@ -6,7 +6,9 @@ module EcsDeploy
       :secret_access_key,
       :default_region,
       :deploy_wait_timeout,
-      :ecs_service_role
+      :ecs_service_role,
+      :ecs_service_wait_until_max_attempts,
+      :ecs_service_wait_until_delay
 
     def initialize
       @log_level = :info

--- a/lib/ecs_deploy/configuration.rb
+++ b/lib/ecs_deploy/configuration.rb
@@ -7,8 +7,8 @@ module EcsDeploy
       :default_region,
       :deploy_wait_timeout,
       :ecs_service_role,
-      :ecs_service_wait_until_max_attempts,
-      :ecs_service_wait_until_delay
+      :ecs_wait_until_services_stable_max_attempts,
+      :ecs_wait_until_services_stable_delay
 
     def initialize
       @log_level = :info

--- a/lib/ecs_deploy/service.rb
+++ b/lib/ecs_deploy/service.rb
@@ -65,7 +65,8 @@ module EcsDeploy
       service = @response.service
 
       @client.wait_until(:services_stable, cluster: @cluster, services: [service.service_name]) do |w|
-        w.delay = 10
+        w.delay = EcsDeploy.config.ecs_service_wait_until_delay if EcsDeploy.config.ecs_service_wait_until_delay
+        w.max_attempts = EcsDeploy.config.ecs_service_wait_until_max_attempts if EcsDeploy.config.ecs_service_wait_until_max_attempts
 
         w.before_attempt do
           EcsDeploy.logger.info "wait service stable [#{service.service_name}]"
@@ -78,6 +79,9 @@ module EcsDeploy
         client = Aws::ECS::Client.new(region: region)
         ss.map(&:service_name).each_slice(MAX_DESCRIBE_SERVICES) do |chunked_service_names|
           client.wait_until(:services_stable, cluster: cl, services: chunked_service_names) do |w|
+            w.delay = EcsDeploy.config.ecs_service_wait_until_delay if EcsDeploy.config.ecs_service_wait_until_delay
+            w.max_attempts = EcsDeploy.config.ecs_service_wait_until_max_attempts if EcsDeploy.config.ecs_service_wait_until_max_attempts
+
             w.before_attempt do
               EcsDeploy.logger.info "wait service stable [#{chunked_service_names.join(", ")}]"
             end

--- a/lib/ecs_deploy/service.rb
+++ b/lib/ecs_deploy/service.rb
@@ -65,8 +65,8 @@ module EcsDeploy
       service = @response.service
 
       @client.wait_until(:services_stable, cluster: @cluster, services: [service.service_name]) do |w|
-        w.delay = EcsDeploy.config.ecs_service_wait_until_delay if EcsDeploy.config.ecs_service_wait_until_delay
-        w.max_attempts = EcsDeploy.config.ecs_service_wait_until_max_attempts if EcsDeploy.config.ecs_service_wait_until_max_attempts
+        w.delay = EcsDeploy.config.ecs_wait_until_services_stable_delay if EcsDeploy.config.ecs_wait_until_services_stable_delay
+        w.max_attempts = EcsDeploy.config.ecs_wait_until_services_stable_max_attempts if EcsDeploy.config.ecs_wait_until_services_stable_max_attempts
 
         w.before_attempt do
           EcsDeploy.logger.info "wait service stable [#{service.service_name}]"
@@ -79,8 +79,8 @@ module EcsDeploy
         client = Aws::ECS::Client.new(region: region)
         ss.map(&:service_name).each_slice(MAX_DESCRIBE_SERVICES) do |chunked_service_names|
           client.wait_until(:services_stable, cluster: cl, services: chunked_service_names) do |w|
-            w.delay = EcsDeploy.config.ecs_service_wait_until_delay if EcsDeploy.config.ecs_service_wait_until_delay
-            w.max_attempts = EcsDeploy.config.ecs_service_wait_until_max_attempts if EcsDeploy.config.ecs_service_wait_until_max_attempts
+            w.delay = EcsDeploy.config.ecs_wait_until_services_stable_delay if EcsDeploy.config.ecs_wait_until_services_stable_delay
+            w.max_attempts = EcsDeploy.config.ecs_wait_until_services_stable_max_attempts if EcsDeploy.config.ecs_wait_until_services_stable_max_attempts
 
             w.before_attempt do
               EcsDeploy.logger.info "wait service stable [#{chunked_service_names.join(", ")}]"


### PR DESCRIPTION
I want to adjust `wait_until` parameters.
`wait_until` has `delay` and `max_attempts` parameters.

Parameter defaults on `service_stable` waiter is `delay = 15` and `max_attempts = 40`

see also: http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#wait_until-instance_method