### PR TITLE
Use Aws::Plugins::RegionalEndpoint.resolve_region

### DIFF
--- a/lib/ecs_deploy/capistrano.rb
+++ b/lib/ecs_deploy/capistrano.rb
@@ -22,7 +22,7 @@ namespace :ecs do
   task register_task_definition: [:configure] do
     if fetch(:ecs_tasks)
       regions = Array(fetch(:ecs_region))
-      regions = [EcsDeploy.config.default_region || ENV["AWS_DEFAULT_REGION"]] if regions.empty?
+      regions = [EcsDeploy.config.default_region] if regions.empty?
       ecs_registered_tasks = {}
       regions.each do |region|
         ecs_registered_tasks[region] = {}

--- a/lib/ecs_deploy/scheduled_task.rb
+++ b/lib/ecs_deploy/scheduled_task.rb
@@ -21,10 +21,11 @@ module EcsDeploy
       @task_count = task_count || 1
       @revision = revision
       @role_arn = role_arn
-      @region = region || EcsDeploy.config.default_region || ENV["AWS_DEFAULT_REGION"]
+      region ||= EcsDeploy.config.default_region
       @container_overrides = container_overrides
 
-      @client = Aws::ECS::Client.new(region: @region)
+      @client = region ? Aws::ECS::Client.new(region: region) : Aws::ECS::Client.new
+      @region = @client.config.region
       @cloud_watch_events = Aws::CloudWatchEvents::Client.new(region: @region)
     end
 

--- a/lib/ecs_deploy/service.rb
+++ b/lib/ecs_deploy/service.rb
@@ -20,10 +20,11 @@ module EcsDeploy
       @desired_count = desired_count
       @deployment_configuration = deployment_configuration
       @revision = revision
-      @region = region || EcsDeploy.config.default_region || ENV["AWS_DEFAULT_REGION"]
+      region ||= EcsDeploy.config.default_region
       @response = nil
 
-      @client = Aws::ECS::Client.new(region: @region)
+      @client = region ? Aws::ECS::Client.new(region: region) : Aws::ECS::Client.new
+      @region = @client.config.region
     end
 
     def current_task_definition_arn

--- a/lib/ecs_deploy/task_definition.rb
+++ b/lib/ecs_deploy/task_definition.rb
@@ -1,12 +1,12 @@
 module EcsDeploy
   class TaskDefinition
     def self.deregister(arn, region: nil)
-      region = region || EcsDeploy.config.default_region || ENV["AWS_DEFAULT_REGION"]
-      client = Aws::ECS::Client.new(region: region)
+      region ||= EcsDeploy.config.default_region
+      client = region ? Aws::ECS::Client.new(region: region) : Aws::ECS::Client.new
       client.deregister_task_definition({
         task_definition: arn,
       })
-      EcsDeploy.logger.info "deregister task definition [#{arn}] [#{region}] [#{Paint['OK', :green]}]"
+      EcsDeploy.logger.info "deregister task definition [#{arn}] [#{client.config.region}] [#{Paint['OK', :green]}]"
     end
 
     def initialize(
@@ -16,7 +16,7 @@ module EcsDeploy
     )
       @task_definition_name = task_definition_name
       @task_role_arn        = task_role_arn
-      @region = region || EcsDeploy.config.default_region || ENV["AWS_DEFAULT_REGION"]
+      region ||= EcsDeploy.config.default_region
 
       @container_definitions = container_definitions.map do |cd|
         if cd[:docker_labels]
@@ -31,7 +31,8 @@ module EcsDeploy
       @network_mode = network_mode
       @placement_constraints = placement_constraints
 
-      @client = Aws::ECS::Client.new(region: @region)
+      @client = region ? Aws::ECS::Client.new(region: region) : Aws::ECS::Client.new
+      @region = @client.config.region
     end
 
     def recent_task_definition_arns


### PR DESCRIPTION
I want to use the default region of my profile
when I specify AWS_PROFILE environment variable.
Seahorse::Client::Configuration#apply_defaults assigns
default values only to options which are not specified.



* [aws-sdk-core/lib/aws-sdk-core/plugins/regional_endpoint.rb#L11-L27](https://github.com/aws/aws-sdk-ruby/blob/7d55a0d26e55531fd360486f9126f7dda1506d5a/gems/aws-sdk-core/lib/aws-sdk-core/plugins/regional_endpoint.rb#L11-L27)
* [aws-sdk-core/lib/seahorse/client/configuration.rb#L171-L178](https://github.com/aws/aws-sdk-ruby/blob/7d55a0d26e55531fd360486f9126f7dda1506d5a/gems/aws-sdk-core/lib/seahorse/client/configuration.rb#L171-L178)