### PR TITLE
Stop supporting aws-sdk V2

### DIFF
--- a/ecs_deploy.gemspec
+++ b/ecs_deploy.gemspec
@@ -18,7 +18,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "aws-sdk", ">= 2.10.109"
+  spec.add_runtime_dependency "aws-sdk-autoscaling", "~> 1"
+  spec.add_runtime_dependency "aws-sdk-cloudwatch", "~> 1"
+  spec.add_runtime_dependency "aws-sdk-cloudwatchevents", "~> 1"
+  spec.add_runtime_dependency "aws-sdk-ec2", "~> 1"
+  spec.add_runtime_dependency "aws-sdk-ecs", "~> 1"
   spec.add_runtime_dependency "terminal-table"
   spec.add_runtime_dependency "paint"
 

--- a/lib/ecs_deploy.rb
+++ b/lib/ecs_deploy.rb
@@ -1,7 +1,8 @@
 require "ecs_deploy/version"
 require "ecs_deploy/configuration"
 
-require 'aws-sdk'
+require 'aws-sdk-ec2'
+require 'aws-sdk-ecs'
 require 'logger'
 require 'terminal-table'
 require 'paint'

--- a/lib/ecs_deploy/auto_scaler.rb
+++ b/lib/ecs_deploy/auto_scaler.rb
@@ -1,3 +1,5 @@
+require 'aws-sdk-autoscaling'
+require 'aws-sdk-cloudwatch'
 require 'yaml'
 require 'logger'
 require 'time'

--- a/lib/ecs_deploy/scheduled_task.rb
+++ b/lib/ecs_deploy/scheduled_task.rb
@@ -1,3 +1,4 @@
+require 'aws-sdk-cloudwatchevents'
 require 'timeout'
 
 module EcsDeploy


### PR DESCRIPTION
AWS recommends library maintainers use service specific gems.
cf. https://aws.amazon.com/blogs/developer/upgrading-from-version-2-to-version-3-of-the-aws-sdk-for-ruby-2/

Currently all service specific gems will be installed
if there are no gems which depend on aws-sdk V2 in Gemfile.
I think this is not expected behavior.