### PR TITLE
Support scheduling_strategy option

### DIFF
--- a/lib/ecs_deploy/capistrano.rb
+++ b/lib/ecs_deploy/capistrano.rb
@@ -102,6 +102,7 @@ namespace :ecs do
           service_options[:deployment_configuration] = service[:deployment_configuration] if service[:deployment_configuration]
           service_options[:placement_constraints] = service[:placement_constraints] if service[:placement_constraints]
           service_options[:placement_strategy] = service[:placement_strategy] if service[:placement_strategy]
+          service_options[:scheduling_strategy] = service[:scheduling_strategy] if service[:scheduling_strategy]
           s = EcsDeploy::Service.new(service_options)
           s.deploy
           s


### PR DESCRIPTION
Add `scheduling_strategy` option support for [Daemon Scheduling](https://aws.amazon.com/about-aws/whats-new/2018/06/amazon-ecs-adds-daemon-scheduling/).

```ruby
set :ecs_services, [
  {
    name: "hello",
    ...
    scheduling_strategy: "DAEMON"
  }
]
```

@joker1007 Would you please review?