### PR TITLE
Support execution_roke_arn on task_definition

### DIFF
--- a/lib/ecs_deploy/capistrano.rb
+++ b/lib/ecs_deploy/capistrano.rb
@@ -32,6 +32,7 @@ namespace :ecs do
             task_definition_name: t[:name],
             container_definitions: t[:container_definitions],
             task_role_arn: t[:task_role_arn],
+            execution_role_arn: t[:execution_role_arn],
             volumes: t[:volumes],
             network_mode: t[:network_mode],
             placement_constraints: t[:placement_constraints],

--- a/lib/ecs_deploy/task_definition.rb
+++ b/lib/ecs_deploy/task_definition.rb
@@ -13,11 +13,13 @@ module EcsDeploy
       task_definition_name:, region: nil,
       network_mode: "bridge", volumes: [], container_definitions: [], placement_constraints: [],
       task_role_arn: nil,
+      execution_role_arn: nil,
       requires_compatibilities: nil,
       cpu: nil, memory: nil
     )
       @task_definition_name = task_definition_name
       @task_role_arn        = task_role_arn
+      @execution_role_arn   = execution_role_arn
       region ||= EcsDeploy.config.default_region
 
       @container_definitions = container_definitions.map do |cd|
@@ -58,6 +60,7 @@ module EcsDeploy
         volumes: @volumes,
         placement_constraints: @placement_constraints,
         task_role_arn: @task_role_arn,
+        execution_role_arn: @execution_role_arn,
         requires_compatibilities: @requires_compatibilities,
         cpu: @cpu, memory: @memory,
       })


### PR DESCRIPTION
Fargate launch type needs to use `execution_roke_arn` parameter.

@joker1007 please review