### PR TITLE
Consider Timeout::Error in wait_for_capacity_decrease as a warning

### DIFF
--- a/lib/ecs_deploy/auto_scaler/spot_fleet_request_config.rb
+++ b/lib/ecs_deploy/auto_scaler/spot_fleet_request_config.rb
@@ -86,6 +86,8 @@ module EcsDeploy
             sleep 5
           end
         end
+      rescue Timeout::Error => e
+        AutoScaler.error_logger.warn("`#{__method__}': #{e} (#{e.class})")
       end
 
       def calculate_active_instance_capacity(cluster)


### PR DESCRIPTION
In our usage, we receive Timeout::Error a few times a day for the reason like below:

1. The current target capacity is 20 and there are 5 instances which has 4 vCPU
2. The new target capacity is 18 but no instances will be terminated,
  because the capacity will be 16 if one instance are terminated

![image](https://user-images.githubusercontent.com/508822/50054582-c393ce80-0186-11e9-9d8e-cc499ccd1c8b.png)


