### PR TITLE
Remove default ecs_service_role in order to use service-linked role

### DIFF
--- a/lib/ecs_deploy/configuration.rb
+++ b/lib/ecs_deploy/configuration.rb
@@ -13,7 +13,6 @@ module EcsDeploy
     def initialize
       @log_level = :info
       @deploy_wait_timeout = 300
-      @ecs_service_role = "ecsServiceRole"
     end
   end
 end

--- a/lib/ecs_deploy/service.rb
+++ b/lib/ecs_deploy/service.rb
@@ -67,7 +67,7 @@ module EcsDeploy
           placement_strategy: @placement_strategy,
         })
 
-        if EcsDeploy.config.ecs_service_role
+        if @load_balancers && EcsDeploy.config.ecs_service_role
           service_options.merge!({
             role: EcsDeploy.config.ecs_service_role,
           })

--- a/lib/ecs_deploy/service.rb
+++ b/lib/ecs_deploy/service.rb
@@ -66,12 +66,19 @@ module EcsDeploy
           placement_constraints: @placement_constraints,
           placement_strategy: @placement_strategy,
         })
-        if @load_balancers
+
+        if EcsDeploy.config.ecs_service_role
           service_options.merge!({
             role: EcsDeploy.config.ecs_service_role,
+          })
+        end
+
+        if @load_balancers
+          service_options.merge!({
             load_balancers: @load_balancers,
           })
         end
+
         if @scheduling_strategy == 'DAEMON'
           service_options[:scheduling_strategy] = @scheduling_strategy
           service_options.delete(:desired_count)


### PR DESCRIPTION
Current Amazon ECS prefers to use service-linked role.
https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/using-service-linked-roles.html

Because of it, I remove implicit role parameter from API call.
Unless role parameter is given, ECS uses service-linked role automatically.
https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateService.html#ECS-CreateService-request-role