### PR TITLE
Support tagging ECS resources

### DIFF
--- a/lib/ecs_deploy/capistrano.rb
+++ b/lib/ecs_deploy/capistrano.rb
@@ -39,6 +39,7 @@ namespace :ecs do
             requires_compatibilities: t[:requires_compatibilities],
             cpu: t[:cpu],
             memory: t[:memory],
+            tags: t[:tags],
           )
           result = task_definition.register
           ecs_registered_tasks[region][t[:name]] = result
@@ -103,6 +104,9 @@ namespace :ecs do
             network_configuration: service[:network_configuration],
             health_check_grace_period_seconds: service[:health_check_grace_period_seconds],
             delete: service[:delete],
+            enable_ecs_managed_tags: service[:enable_ecs_managed_tags],
+            tags: service[:tags],
+            propagate_tags: service[:propagate_tags],
           }
           service_options[:deployment_configuration] = service[:deployment_configuration] if service[:deployment_configuration]
           service_options[:placement_constraints] = service[:placement_constraints] if service[:placement_constraints]

--- a/lib/ecs_deploy/task_definition.rb
+++ b/lib/ecs_deploy/task_definition.rb
@@ -15,7 +15,8 @@ module EcsDeploy
       task_role_arn: nil,
       execution_role_arn: nil,
       requires_compatibilities: nil,
-      cpu: nil, memory: nil
+      cpu: nil, memory: nil,
+      tags: nil
     )
       @task_definition_name = task_definition_name
       @task_role_arn        = task_role_arn
@@ -37,6 +38,7 @@ module EcsDeploy
       @requires_compatibilities = requires_compatibilities
       @cpu = cpu&.to_s
       @memory = memory&.to_s
+      @tags = tags
 
       @client = region ? Aws::ECS::Client.new(region: region) : Aws::ECS::Client.new
       @region = @client.config.region
@@ -63,6 +65,7 @@ module EcsDeploy
         execution_role_arn: @execution_role_arn,
         requires_compatibilities: @requires_compatibilities,
         cpu: @cpu, memory: @memory,
+        tags: @tags
       })
       EcsDeploy.logger.info "register task definition [#{@task_definition_name}] [#{@region}] [#{Paint['OK', :green]}]"
       res.task_definition


### PR DESCRIPTION
This PR supports [tagging ECS resources](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-using-tags.html).
We can tag task definitions and services like below:

```ruby
set :ecs_tasks, [
  {
    name: "sleep",
    container_definitions: [{
      image: "ubuntu",
      cpu: 256,
      memory: 100,
      essential: true,
      name: "sleep",
      command: ["sleep", "3600"],
    }],
    tags: [{ key: 'Image', value: 'ubuntu' }],
  },
]

set :ecs_services, [
  {
    name: "sleep",
    desired_count: 1,
    deployment_configuration: {maximum_percent: 100, minimum_healthy_percent: 0},
    tags: [
      { key: 'ServiceName', value: 'sleep' },
    ],
    enable_ecs_managed_tags: true,
    propagate_tags: 'SERVICE',
  }
]
```