### PR TITLE
Resolve InvalidParameterException caused by old ARN formats

### DIFF
--- a/lib/ecs_deploy/service.rb
+++ b/lib/ecs_deploy/service.rb
@@ -117,8 +117,10 @@ module EcsDeploy
 
     def update_tags(service_name, tags)
       service_arn = @client.describe_services(services: [service_name]).services.first.service_arn
-      if service_arn.split('/').size == 2 && tags
-        EcsDeploy.logger.warn "#{service_name} doesn't support tagging operations, so tags are ignored. Long arn format must be used for tagging operations."
+      if service_arn.split('/').size == 2
+        if tags
+          EcsDeploy.logger.warn "#{service_name} doesn't support tagging operations, so tags are ignored. Long arn format must be used for tagging operations."
+        end
         return
       end
 

--- a/lib/ecs_deploy/service.rb
+++ b/lib/ecs_deploy/service.rb
@@ -116,7 +116,7 @@ module EcsDeploy
     end
 
     def update_tags(service_name, tags)
-      service_arn = @client.describe_services(services: [service_name]).services.first.service_arn
+      service_arn = @client.describe_services(cluster: @cluster, services: [service_name]).services.first.service_arn
       if service_arn.split('/').size == 2
         if tags
           EcsDeploy.logger.warn "#{service_name} doesn't support tagging operations, so tags are ignored. Long arn format must be used for tagging operations."


### PR DESCRIPTION
`Aws::ECS::Errors::InvalidParameterException: Long arn format must be used for tagging operations` occurs when we try to update ECS services whose ARN is in old format.
This PR resolves it.