### PR TITLE
Wait until stopping tasks stops

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ I recommends deploy `ecs_auto_scaler` on ECS too.
 
 ### IAM policy for autoscaler
 
-The following policy is required for the preceding configuration of "repro-api-production" service:
+The following permissions are required for the preceding configuration of "repro-api-production" service:
 
 ```
 {
@@ -303,14 +303,28 @@ The following policy is required for the preceding configuration of "repro-api-p
         "cloudwatch:DescribeAlarms",
         "ec2:DescribeInstances",
         "ec2:TerminateInstances",
-        "ecs:DescribeContainerInstances",
-        "ecs:DescribeServices",
-        "ecs:DescribeTasks",
-        "ecs:ListContainerInstances",
-        "ecs:ListTasks",
-        "ecs:UpdateService"
+        "ecs:ListTasks"
       ],
       "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeServices",
+        "ecs:UpdateService"
+      ],
+      "Resource": [
+        "arn:aws:ecs:ap-northeast-1:<account-id>:service/ecs-cluster/repro-api-production"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeTasks"
+      ],
+      "Resource": [
+        "arn:aws:ecs:ap-northeast-1:<account-id>:task/ecs-cluster/*"
+      ]
     },
     {
       "Effect": "Allow",
@@ -325,7 +339,17 @@ The following policy is required for the preceding configuration of "repro-api-p
     {
       "Effect": "Allow",
       "Action": [
-        "ecs:DeregisterContainerInstance"
+        "ecs:DescribeContainerInstances"
+      ],
+      "Resource": [
+        "arn:aws:ecs:ap-northeast-1:<account-id>:container-instance/ecs-cluster/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DeregisterContainerInstance",
+        "ecs:ListContainerInstances"
       ],
       "Resource": [
         "arn:aws:ecs:ap-northeast-1:<account-id>:cluster/ecs-cluster"
@@ -335,7 +359,7 @@ The following policy is required for the preceding configuration of "repro-api-p
 }
 ```
 
-The following policy is required for the preceding configuration of "repro-worker-production" service:
+The following permissions are required for the preceding configuration of "repro-worker-production" service:
 
 ```
 {
@@ -369,14 +393,46 @@ The following policy is required for the preceding configuration of "repro-worke
         "ec2:DescribeSpotFleetRequests",
         "ec2:ModifySpotFleetRequest",
         "ec2:TerminateInstances",
-        "ecs:DescribeContainerInstances",
-        "ecs:DescribeServices",
-        "ecs:DescribeTasks",
-        "ecs:ListContainerInstances",
-        "ecs:ListTasks",
-        "ecs:UpdateService"
+        "ecs:ListTasks"
       ],
       "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeServices",
+        "ecs:UpdateService"
+      ],
+      "Resource": [
+        "arn:aws:ecs:ap-northeast-1:<account-id>:service/ecs-cluster-for-worker/repro-worker-production"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeTasks"
+      ],
+      "Resource": [
+        "arn:aws:ecs:ap-northeast-1:<account-id>:task/ecs-cluster-for-worker/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeContainerInstances"
+      ],
+      "Resource": [
+        "arn:aws:ecs:ap-northeast-1:<account-id>:container-instance/ecs-cluster-for-worker/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecs:ListContainerInstances"
+      ],
+      "Resource": [
+        "arn:aws:ecs:ap-northeast-1:<account-id>:cluster/ecs-cluster-for-worker"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -305,7 +305,9 @@ The following policy is required for the preceding configuration of "repro-api-p
         "ec2:TerminateInstances",
         "ecs:DescribeContainerInstances",
         "ecs:DescribeServices",
+        "ecs:DescribeTasks",
         "ecs:ListContainerInstances",
+        "ecs:ListTasks",
         "ecs:UpdateService"
       ],
       "Resource": "*"
@@ -362,14 +364,16 @@ The following policy is required for the preceding configuration of "repro-worke
       "Effect": "Allow",
       "Action": [
         "cloudwatch:DescribeAlarms",
-        "ec2:ModifySpotFleetRequest",
         "ec2:DescribeInstances",
-        "ec2:TerminateInstances",
-        "ecs:ListContainerInstances",
-        "ecs:DescribeContainerInstances",
-        "ecs:DescribeServices",
         "ec2:DescribeSpotFleetInstances",
         "ec2:DescribeSpotFleetRequests",
+        "ec2:ModifySpotFleetRequest",
+        "ec2:TerminateInstances",
+        "ecs:DescribeContainerInstances",
+        "ecs:DescribeServices",
+        "ecs:DescribeTasks",
+        "ecs:ListContainerInstances",
+        "ecs:ListTasks",
         "ecs:UpdateService"
       ],
       "Resource": "*"

--- a/README.md
+++ b/README.md
@@ -359,6 +359,35 @@ The following permissions are required for the preceding configuration of "repro
 }
 ```
 
+If you use spot instances, additional permissions are required like below:
+
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "ecs:UpdateContainerInstancesState",
+      "Resource": "*",
+      "Condition": {
+        "ArnEquals": {
+          "ecs:cluster": "arn:aws:ecs:ap-northeast-1:<account-id>:cluster/ecs-cluster"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sqs:DeleteMessage",
+        "sqs:DeleteMessageBatch",
+        "sqs:ReceiveMessage"
+      ],
+      "Resource": "arn:aws:sqs:ap-northeast-1:<account-id>:spot-instance-intrp-warns"
+    }
+  ]
+}
+```
+
 The following permissions are required for the preceding configuration of "repro-worker-production" service:
 
 ```

--- a/lib/ecs_deploy/auto_scaler/auto_scaling_group_config.rb
+++ b/lib/ecs_deploy/auto_scaler/auto_scaling_group_config.rb
@@ -9,6 +9,8 @@ module EcsDeploy
     AutoScalingGroupConfig = Struct.new(:name, :region, :buffer) do
       include ConfigBase
 
+      MAX_DETACHABLE_INSTANCE_COUNT = 20
+
       def update_desired_capacity(required_capacity, service_config)
         detach_and_terminate_orphan_instances(service_config)
 

--- a/lib/ecs_deploy/auto_scaler/service_config.rb
+++ b/lib/ecs_deploy/auto_scaler/service_config.rb
@@ -10,6 +10,7 @@ module EcsDeploy
       include ConfigBase
 
       MAX_DETACHABLE_INSTANCE_COUNT = 20
+      MAX_DESCRIBABLE_TASK_COUNT = 100
 
       def initialize(attributes = {}, logger)
         super
@@ -171,23 +172,45 @@ module EcsDeploy
           @logger.info "Service \"#{name}\" clears cooldown state"
         end
 
-        cl = client
         next_desired_count = [next_desired_count, max_task_count[level]].min
+        update_service_desired_count(next_desired_count)
+
+        @last_updated_at = Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
+        self.desired_count = next_desired_count
+        @logger.info "Update service \"#{name}\": desired_count -> #{next_desired_count}"
+      rescue => e
+        pp e
+        AutoScaler.error_logger.error(e)
+      end
+
+      def update_service_desired_count(next_desired_count)
+        cl = client
+        if next_desired_count < desired_count
+          running_task_arns = cl.list_tasks(cluster: cluster, service_name: name, desired_status: "RUNNING").flat_map(&:task_arns)
+        end
+
         cl.update_service(
           cluster: cluster,
           service: name,
           desired_count: next_desired_count,
         )
+
+        return if next_desired_count >= desired_count
+
         cl.wait_until(:services_stable, cluster: cluster, services: [name]) do |w|
           w.before_wait do
             @logger.debug "wait service stable [#{name}]"
           end
-        end if difference < 0
-        @last_updated_at = Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
-        self.desired_count = next_desired_count
-        @logger.info "Update service \"#{name}\": desired_count -> #{next_desired_count}"
-      rescue => e
-        AutoScaler.error_logger.error(e)
+        end
+
+        stopping_task_arns = running_task_arns - cl.list_tasks(cluster: cluster, service_name: name, desired_status: "RUNNING").flat_map(&:task_arns)
+        stopping_task_arns.each_slice(MAX_DESCRIBABLE_TASK_COUNT) do |arns|
+          cl.wait_until(:tasks_stopped, cluster: cluster, tasks: arns) do |w|
+            w.before_wait do
+              @logger.debug "wait stopping tasks stopped [#{name}]"
+            end
+          end
+        end
       end
 
       def max_task_level(count)

--- a/lib/ecs_deploy/auto_scaler/service_config.rb
+++ b/lib/ecs_deploy/auto_scaler/service_config.rb
@@ -9,7 +9,6 @@ module EcsDeploy
     ServiceConfig = Struct.new(*SERVICE_CONFIG_ATTRIBUTES) do
       include ConfigBase
 
-      MAX_DETACHABLE_INSTANCE_COUNT = 20
       MAX_DESCRIBABLE_TASK_COUNT = 100
 
       def initialize(attributes = {}, logger)

--- a/lib/ecs_deploy/auto_scaler/service_config.rb
+++ b/lib/ecs_deploy/auto_scaler/service_config.rb
@@ -178,7 +178,6 @@ module EcsDeploy
         self.desired_count = next_desired_count
         @logger.info "Update service \"#{name}\": desired_count -> #{next_desired_count}"
       rescue => e
-        pp e
         AutoScaler.error_logger.error(e)
       end
 


### PR DESCRIPTION
`Aws::ECS::Client#wait_until(:services_stable, ...)` waits until the running count of
the service become the value of `desired_count`.
cf. https://github.com/aws/aws-sdk-ruby/blob/1d6754a6a13aaf87cf7f1f66f211a9ee69301733/gems/aws-sdk-ecs/lib/aws-sdk-ecs/waiters.rb#L91-L96

The running count doesn't include the count of stopping tasks, so ecs_auto_scaler
can terminate instances where some stopping tasks are running.

This PR resolves the issue.