### PR TITLE
Allow the use of  Bundler 2

### DIFF
--- a/ecs_deploy.gemspec
+++ b/ecs_deploy.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "terminal-table"
   spec.add_runtime_dependency "paint"
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", ">= 1.11", "< 3"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
This PR resolves the following error:

```
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.11)

  Current Bundler version:
    bundler (2.0.2)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (~> 1.11)' in any of the relevant sources:
  the local ruby installation
```