### PR TITLE
Fix "undefined local variable or method `e'"

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,12 +363,7 @@ If you use spot instances, additional permissions are required like below:
     {
       "Effect": "Allow",
       "Action": "ecs:UpdateContainerInstancesState",
-      "Resource": "*",
-      "Condition": {
-        "ArnEquals": {
-          "ecs:cluster": "arn:aws:ecs:ap-northeast-1:<account-id>:cluster/ecs-cluster"
-        }
-      }
+      "Resource": "arn:aws:ecs:ap-northeast-1:<account-id>:container-instance/ecs-cluster/*"
     },
     {
       "Effect": "Allow",
@@ -389,16 +384,6 @@ The following permissions are required for the preceding configuration of "repro
 {
   "Version": "2012-10-17",
   "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": "ecs:UpdateContainerInstancesState",
-      "Resource": "*",
-      "Condition": {
-        "ArnEquals": {
-          "ecs:cluster": "arn:aws:ecs:ap-northeast-1:<account-id>:cluster/ecs-cluster-for-worker"
-        }
-      }
-    },
     {
       "Effect": "Allow",
       "Action": [
@@ -443,7 +428,8 @@ The following permissions are required for the preceding configuration of "repro
     {
       "Effect": "Allow",
       "Action": [
-        "ecs:DescribeContainerInstances"
+        "ecs:DescribeContainerInstances",
+        "ecs:UpdateContainerInstancesState"
       ],
       "Resource": [
         "arn:aws:ecs:ap-northeast-1:<account-id>:container-instance/ecs-cluster-for-worker/*"

--- a/lib/ecs_deploy/auto_scaler/cluster_resource_manager.rb
+++ b/lib/ecs_deploy/auto_scaler/cluster_resource_manager.rb
@@ -97,7 +97,7 @@ module EcsDeploy
           @logger&.info "#{log_prefix} Wait for the capacity of active instances to become #{new_desired_capacity} from #{old_desired_capacity}"
           begin
             th.join
-          rescue Timeout::Error
+          rescue Timeout::Error => e
             msg = "#{log_prefix} `#{__method__}': #{e} (#{e.class})"
             if @capacity_based_on == "vCPUs"
               # Timeout::Error sometimes occur.


### PR DESCRIPTION
This PR fixes an error like below:

```
E, [2019-09-25T00:31:42.704520 #14230] ERROR -- : undefined local variable or method `e' for #<EcsDeploy::AutoScaler::ClusterResourceManager:0x00007f9cdca609c0> (NameError)
/Users/arabiki/ghq/src/github.com/reproio/ecs_deploy/lib/ecs_deploy/auto_scaler/cluster_resource_manager.rb:101:in `rescue in trigger_capacity_update'
/Users/arabiki/ghq/src/github.com/reproio/ecs_deploy/lib/ecs_deploy/auto_scaler/cluster_resource_manager.rb:98:in `trigger_capacity_update'
/Users/arabiki/ghq/src/github.com/reproio/ecs_deploy/lib/ecs_deploy/auto_scaler/spot_fleet_request_config.rb:40:in `update_desired_capacity'
/Users/arabiki/ghq/src/github.com/reproio/ecs_deploy/lib/ecs_deploy/auto_scaler.rb:64:in `block in main_loop'
/Users/arabiki/ghq/src/github.com/reproio/ecs_deploy/lib/ecs_deploy/auto_scaler.rb:163:in `block in loop_with_polling_interval'
/Users/arabiki/ghq/src/github.com/reproio/ecs_deploy/lib/ecs_deploy/auto_scaler.rb:158:in `loop'
/Users/arabiki/ghq/src/github.com/reproio/ecs_deploy/lib/ecs_deploy/auto_scaler.rb:158:in `loop_with_polling_interval'
/Users/arabiki/ghq/src/github.com/reproio/ecs_deploy/lib/ecs_deploy/auto_scaler.rb:50:in `main_loop'
```

After this change is applied, a log will be displayed as below:

```
W, [2019-09-25T00:36:48.483303 #14436]  WARN -- : [EcsDeploy::AutoScaler::ClusterResourceManager, region: ap-northeast-1, cluster: test] `trigger_capacity_update': execution expired (Timeout::Error)
```

I also modify the example IAM policy to reduce its size. The maximum byte size of IAM policy is 2048.