### PR TITLE
Detach interrupted instances from ASG to launch other instances

### DIFF
--- a/lib/ecs_deploy/auto_scaler/cluster_resource_manager.rb
+++ b/lib/ecs_deploy/auto_scaler/cluster_resource_manager.rb
@@ -142,7 +142,7 @@ module EcsDeploy
       end
 
       def log_prefix
-        "[#{self.class}, region: #{@region}, cluster: #{@cluster}]"
+        "[#{self.class.to_s.gsub(/\AEcsDeploy::AutoScaler::/, "")} #{@region} #{@cluster}]"
       end
     end
   end

--- a/lib/ecs_deploy/auto_scaler/instance_drainer.rb
+++ b/lib/ecs_deploy/auto_scaler/instance_drainer.rb
@@ -1,6 +1,7 @@
 require "aws-sdk-ec2"
 require "aws-sdk-ecs"
 require "aws-sdk-sqs"
+
 require "ecs_deploy"
 
 module EcsDeploy
@@ -18,14 +19,8 @@ module EcsDeploy
 
         # cf. https://docs.aws.amazon.com/general/latest/gr/rande.html#sqs_region
         region = URI.parse(queue_url).host.split(".")[1]
-        sqs_client = Aws::SQS::Client.new(
-          access_key_id: EcsDeploy.config.access_key_id,
-          secret_access_key: EcsDeploy.config.secret_access_key,
-          region: region,
-          logger: @logger,
-        )
 
-        poller = Aws::SQS::QueuePoller.new(queue_url, client: sqs_client)
+        poller = Aws::SQS::QueuePoller.new(queue_url, client: sqs_client(region))
         poller.before_request do |stats|
           throw :stop_polling if @stop
         end
@@ -36,7 +31,11 @@ module EcsDeploy
               instance_ids = messages.map do |msg|
                 JSON.parse(msg.body).dig("detail", "instance-id")
               end
-              set_instance_state_to_draining(instance_ids, region)
+
+              config_to_instance_ids = build_config_to_instance_ids(instance_ids, region)
+              set_instance_state_to_draining(config_to_instance_ids, region)
+              # Detach the instances to launch other instances
+              detach_instances_from_auto_scaling_groups(config_to_instance_ids, region)
             end
           rescue => e
             AutoScaler.error_logger.error(e)
@@ -52,29 +51,35 @@ module EcsDeploy
 
       private
 
-      def set_instance_state_to_draining(instance_ids, region)
-        cluster_to_instance_ids = Hash.new{ |h, k| h[k] = [] }
-        ec2_client(region).describe_instances(instance_ids: instance_ids).reservations.each do |reservation|
-          reservation.instances.each do |i|
-            sfr_id = i.tags.find { |t| t.key == "aws:ec2spot:fleet-request-id" }&.value
-            if sfr_id
-              config = @spot_fleet_request_configs.find { |c| c.id == sfr_id && c.region == region }
-              cluster_to_instance_ids[config.cluster] << i.instance_id if config
-              next
-            end
+      def build_config_to_instance_ids(instance_ids, region)
+        config_to_instance_ids = Hash.new{ |h, k| h[k] = [] }
+        ec2_client(region).describe_instances(instance_ids: instance_ids).each do |resp|
+          resp.reservations.each do |reservation|
+            reservation.instances.each do |i|
+              sfr_id = i.tags.find { |t| t.key == "aws:ec2spot:fleet-request-id" }&.value
+              if sfr_id
+                config = @spot_fleet_request_configs.find { |c| c.id == sfr_id && c.region == region }
+                config_to_instance_ids[config] << i.instance_id if config
+                next
+              end
 
-            asg_name = i.tags.find { |t| t.key == "aws:autoscaling:groupName" }&.value
-            if asg_name
-              config = @auto_scaling_group_configs.find { |c| c.name == asg_name && c.region == region }
-              cluster_to_instance_ids[config.cluster] << i.instance_id if config
+              asg_name = i.tags.find { |t| t.key == "aws:autoscaling:groupName" }&.value
+              if asg_name
+                config = @auto_scaling_group_configs.find { |c| c.name == asg_name && c.region == region }
+                config_to_instance_ids[config] << i.instance_id if config
+              end
             end
           end
         end
 
+        config_to_instance_ids
+      end
+
+      def set_instance_state_to_draining(config_to_instance_ids, region)
         cl = ecs_client(region)
-        cluster_to_instance_ids.each do |cluster, instance_ids|
+        config_to_instance_ids.each do |config, instance_ids|
           arns = cl.list_container_instances(
-            cluster: cluster,
+            cluster: config.cluster,
             filter: "ec2InstanceId in [#{instance_ids.join(",")}]",
           ).container_instance_arns
 
@@ -84,11 +89,17 @@ module EcsDeploy
           next if arns.empty?
 
           cl.update_container_instances_state(
-            cluster: cluster,
+            cluster: config.cluster,
             container_instances: arns,
             status: "DRAINING",
           )
-          @logger.info "Draining instances: region: #{region}, cluster: #{cluster}, instance_ids: #{instance_ids.inspect}, container_instance_arns: #{arns.inspect}"
+          @logger.info "Draining instances: region: #{region}, cluster: #{config.cluster}, instance_ids: #{instance_ids.inspect}, container_instance_arns: #{arns.inspect}"
+        end
+      end
+
+      def detach_instances_from_auto_scaling_groups(config_to_instance_ids, region)
+        @auto_scaling_group_configs.each do |config|
+          config.detach_instances(instance_ids: config_to_instance_ids[config], should_decrement_desired_capacity: false)
         end
       end
 
@@ -103,6 +114,15 @@ module EcsDeploy
 
       def ecs_client(region)
         Aws::ECS::Client.new(
+          access_key_id: EcsDeploy.config.access_key_id,
+          secret_access_key: EcsDeploy.config.secret_access_key,
+          region: region,
+          logger: @logger,
+        )
+      end
+
+      def sqs_client(region)
+        Aws::SQS::Client.new(
           access_key_id: EcsDeploy.config.access_key_id,
           secret_access_key: EcsDeploy.config.secret_access_key,
           region: region,

--- a/lib/ecs_deploy/auto_scaler/spot_fleet_request_config.rb
+++ b/lib/ecs_deploy/auto_scaler/spot_fleet_request_config.rb
@@ -43,7 +43,7 @@ module EcsDeploy
           # Wait until the capacity is updated to prevent the process from terminating before container draining is completed
           wait_until_capacity_updated: desired_capacity < request_config.target_capacity,
         )
-        @logger.info "Update spot fleet request \"#{id}\": desired_capacity -> #{desired_capacity}"
+        @logger.info "#{log_prefix} Update desired_capacity to #{desired_capacity}"
       rescue => e
         AutoScaler.error_logger.error(e)
       end
@@ -80,7 +80,7 @@ module EcsDeploy
         # because we can't terminate canceled spot instances by decreasing the capacity
         ec2_client.terminate_instances(instance_ids: instance_ids)
 
-        @logger.info "Terminated instances: #{instance_ids.inspect}"
+        @logger.info "#{log_prefix} Terminated instances: #{instance_ids.inspect}"
       rescue => e
         AutoScaler.error_logger.error(e)
       end
@@ -92,6 +92,10 @@ module EcsDeploy
           region: region,
           logger: logger,
         )
+      end
+
+      def log_prefix
+        "[#{self.class.to_s.sub(/\AEcsDeploy::AutoScaler::/, "")} #{name} #{region}]"
       end
     end
   end

--- a/spec/ecs_deploy/auto_scaler/instance_drainer_spec.rb
+++ b/spec/ecs_deploy/auto_scaler/instance_drainer_spec.rb
@@ -1,71 +1,93 @@
 require "spec_helper"
 
+require "ecs_deploy/auto_scaler/auto_scaling_group_config"
 require "ecs_deploy/auto_scaler/instance_drainer"
 
 RSpec.describe EcsDeploy::AutoScaler::InstanceDrainer do
   describe "#poll_spot_instance_interruption_warnings" do
     subject(:drainer) do
       described_class.new(
-        auto_scaling_group_configs: [double(name: "asg_name", region: "ap-northeast-1", cluster: "ecs-cluster")],
+        auto_scaling_group_configs: [asg_config],
         spot_fleet_request_configs: [double(id: "sfr_id", region: "ap-northeast-1", cluster: nil)],
         logger: Logger.new(nil),
       )
     end
 
+    let(:asg_config) do
+      instance_double("EcsDeploy::AutoScaler::AutoScalingGroupConfig",
+        name: "asg_name",
+        region: "ap-northeast-1",
+        cluster: "ecs-cluster",
+      )
+    end
+
     let(:instances) do
       [
-        Aws::EC2::Types::Instance.new(instance_id: 'i-000000', tags: [double(key: "aws:ec2spot:fleet-request-id", value: "sfr_id")]),
-        Aws::EC2::Types::Instance.new(instance_id: 'i-111111', tags: [double(key: "aws:ec2spot:fleet-request-id", value: "another_sfr_id")]),
-        Aws::EC2::Types::Instance.new(instance_id: 'i-222222', tags: [double(key: "aws:autoscaling:groupName", value: "asg_name")]),
-        Aws::EC2::Types::Instance.new(instance_id: 'i-333333', tags: [double(key: "aws:autoscaling:groupName", value: "another_asg_name")]),
-        Aws::EC2::Types::Instance.new(instance_id: 'i-444444', tags: []),
+        { instance_id: 'i-000000', tags: [{ key: "aws:ec2spot:fleet-request-id", value: "sfr_id" }] },
+        { instance_id: 'i-111111', tags: [{ key: "aws:ec2spot:fleet-request-id", value: "another_sfr_id" }] },
+        { instance_id: 'i-222222', tags: [{ key: "aws:autoscaling:groupName", value: "asg_name" }] },
+        { instance_id: 'i-333333', tags: [{ key: "aws:autoscaling:groupName", value: "another_asg_name" }] },
+        { instance_id: 'i-444444', tags: [] },
       ]
     end
 
     let(:messages) do
       instances.map do |i|
-        double(
-          body: %Q|{"detail":{"instance-id":"#{i.instance_id}"}}|,
-          message_id: i.instance_id,
-          receipt_handle: nil,
-        )
+        {
+          body: %Q|{"version":"0","id":"478e68b4-9ad3-1fb4-e8a2-aef2d793738d","detail-type":"EC2 Spot Instance Interruption Warning","source":"aws.ec2","account":"1234","time":"2019-10-05T14:19:37Z","region":"ap-northeast-1","resources":["arn:aws:ec2:ap-northeast-1a:instance/#{i[:instance_id]}"],"detail":{"instance-id":"#{i[:instance_id]}","instance-action":"terminate"}}|,
+        }
       end
     end
 
+    let(:ec2_client) { Aws::EC2::Client.new(stub_responses: true) }
+    let(:ecs_client) { Aws::ECS::Client.new(stub_responses: true) }
+    let(:sqs_client) { Aws::SQS::Client.new(stub_responses: true) }
+
     before do
-      allow_any_instance_of(Aws::SQS::Client).to receive(:receive_message).and_return(double(messages: messages))
-      allow_any_instance_of(Aws::SQS::Client).to receive(:delete_message_batch) do
+      allow(drainer).to receive(:ec2_client) { ec2_client }
+      allow(drainer).to receive(:ecs_client) { ecs_client }
+      allow(drainer).to receive(:sqs_client) { sqs_client }
+
+      sqs_client.stub_responses(:receive_message, { messages: messages })
+      allow(sqs_client).to receive(:delete_message_batch) do
         drainer.stop
         throw :stop_polling
       end
 
-      allow_any_instance_of(Aws::EC2::Client).to receive(:describe_instances).with(
-        instance_ids: instances.map(&:instance_id)
-      ).and_return(double(reservations: [double(instances: instances)]))
+      ec2_client.stub_responses(:describe_instances, ->(context) {
+        if context.params[:instance_ids] == instances.map { |i| i[:instance_id] }
+          { reservations: [{ instances: instances }] }
+        else
+          {}
+        end
+      })
+
+      ecs_client.stub_responses(:list_container_instances, ->(context) {
+        if context.params[:cluster] == nil && context.params[:filter] == "ec2InstanceId in [i-000000]"
+          { container_instance_arns: ["arn:i-000000"] }
+        elsif context.params[:cluster] == "ecs-cluster" && context.params[:filter] == "ec2InstanceId in [i-222222]"
+          { container_instance_arns: ["arn:i-222222"] }
+        else
+          {}
+        end
+      })
     end
 
-    it "updates the state of instances to be interrupted to 'DRAINING'" do
-      expect_any_instance_of(Aws::ECS::Client).to receive(:list_container_instances).with(
-        cluster: nil,
-        filter: "ec2InstanceId in [i-000000]",
-      ).and_return(double(container_instance_arns: ["arn:i-000000"]))
-      expect_any_instance_of(Aws::ECS::Client).to receive(:list_container_instances).with(
-        cluster: "ecs-cluster",
-        filter: "ec2InstanceId in [i-222222]",
-      ).and_return(double(container_instance_arns: ["arn:i-222222"]))
-
-      expect_any_instance_of(Aws::ECS::Client).to receive(:update_container_instances_state).with(
-        cluster: nil,
-        container_instances: ["arn:i-000000"],
-        status: "DRAINING",
-      ).and_return("arn:i-000000")
-      expect_any_instance_of(Aws::ECS::Client).to receive(:update_container_instances_state).with(
-        cluster: "ecs-cluster",
-        container_instances: ["arn:i-222222"],
-        status: "DRAINING",
-      ).and_return("arn:i-222222")
+    it "updates the state of interrupted instances to 'DRAINING'" do
+      expect(asg_config).to receive(:detach_instances).with(instance_ids: ["i-222222"], should_decrement_desired_capacity: false)
 
       drainer.poll_spot_instance_interruption_warnings("https://sqs.ap-northeast-1.amazonaws.com/account_id/queue_name")
+
+      expect(ecs_client.api_requests).to include({
+        operation_name: :update_container_instances_state,
+        params: { cluster: nil, container_instances: ["arn:i-000000"], status: "DRAINING" },
+        context: a_kind_of(Seahorse::Client::RequestContext),
+      })
+      expect(ecs_client.api_requests).to include({
+        operation_name: :update_container_instances_state,
+        params: { cluster: "ecs-cluster", container_instances: ["arn:i-222222"], status: "DRAINING" },
+        context: a_kind_of(Seahorse::Client::RequestContext),
+      })
     end
   end
 end


### PR DESCRIPTION
It takes about two minutes for auto scaling groups to launch new instances after we receive interruption warnings of their instances, so this PR will improve the stability of auto scaling groups managed by ecs_auto_scaler.

This PR will also resolve errors like "Aws::AutoScaling::Errors::ValidationError The instance
i-xxxxxxxxxxxxxxxxx is not in InService or Standby." in `detach_and_terminate_orphan_instances`.
These errors seem to occur in the following steps:

1. Spot instances are interrupted
2. The instances are deregistered from their ECS cluster due to termination
3. AutoScalingGroupConfig calls `detach_and_terminate_orphan_instances`
4. The instances are detached from their auto scaling group due to termination
5. AutoScalingGroupConfig tries to detach instances in detach_and_terminate_orphan_instances