### PR TITLE
Detach only auto scaling group instances

### DIFF
--- a/lib/ecs_deploy/auto_scaler/auto_scaling_group_config.rb
+++ b/lib/ecs_deploy/auto_scaler/auto_scaling_group_config.rb
@@ -82,13 +82,16 @@ module EcsDeploy
       def decrease_desired_capacity(count)
         container_instance_arns_in_service = cluster_resource_manager.fetch_container_instance_arns_in_service
         container_instances_in_cluster = cluster_resource_manager.fetch_container_instances_in_cluster
+        auto_scaling_group_instances = instances(reload: true)
         deregisterable_instances = container_instances_in_cluster.select do |i|
-          i.pending_tasks_count == 0 && !running_essential_task?(i, container_instance_arns_in_service)
+          i.pending_tasks_count == 0 &&
+            !running_essential_task?(i, container_instance_arns_in_service) &&
+            auto_scaling_group_instances.any? {|instance| instance.instance_id == i.ec2_instance_id }
         end
 
         @logger.info "#{log_prefix} Fetch deregisterable instances: #{deregisterable_instances.map(&:ec2_instance_id).inspect}"
 
-        az_to_instance_count = instances(reload: true).each_with_object(Hash.new(0)) { |i, h| h[i.availability_zone] += 1 }
+        az_to_instance_count = instances(reload: false).each_with_object(Hash.new(0)) { |i, h| h[i.availability_zone] += 1 }
         az_to_deregisterable_instances = deregisterable_instances.group_by do |i|
           i.attributes.find { |a| a.name == "ecs.availability-zone" }.value
         end

--- a/lib/ecs_deploy/auto_scaler/auto_scaling_group_config.rb
+++ b/lib/ecs_deploy/auto_scaler/auto_scaling_group_config.rb
@@ -91,7 +91,7 @@ module EcsDeploy
 
         @logger.info "#{log_prefix} Fetch deregisterable instances: #{deregisterable_instances.map(&:ec2_instance_id).inspect}"
 
-        az_to_instance_count = instances(reload: false).each_with_object(Hash.new(0)) { |i, h| h[i.availability_zone] += 1 }
+        az_to_instance_count = auto_scaling_group_instances.each_with_object(Hash.new(0)) { |i, h| h[i.availability_zone] += 1 }
         az_to_deregisterable_instances = deregisterable_instances.group_by do |i|
           i.attributes.find { |a| a.name == "ecs.availability-zone" }.value
         end


### PR DESCRIPTION
This commit fixes the following error.

```
detach_instances(auto_scaling_group_name:"xxxx",instance_ids:["i-000","i-111"],should_decrement_desired_capacity:true) Aws::AutoScaling::Errors::ValidationError The instance i-000 is not part of Auto Scaling group xxxx.
```

This error can happen in the following scenario.

1. InstanceDrainer drains and detaches interrupted spot instances
2. These instances are detached from an ASG almost immediately
3. ECS auto scaler starts scaling down an ECS cluster before they are deregistered from an ECS cluster
4. AutoScalingGroupConfig tries to detach them
5. `The instance i-xxxxx is not part of Auto Scaling group xxxx` error happens
   because these instances are already detached form an ASG in step 2

In this commit, AutoScalingGroupConfig tries to detach only auto scaling group instances
to avoid the error.