### PR TITLE
Add prioritized_over_upscale_triggers option to triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,9 @@ spot_fleet_requests:
         downscale_triggers:
           - alarm_name: "ECS [repro-worker-production] CPUUtilization (low)"
             state: OK
+          - alarm_name: "Aurora DMLLatency is high"
+            state: ALARM
+            prioritized_over_upscale_triggers: true
 
 # If you specify `spot_instance_intrp_warns_queue_urls` as SQS queue for spot instance interruption warnings,
 # autoscaler will polls them and set the state of instances to be intrrupted to "DRAINING".

--- a/lib/ecs_deploy/auto_scaler/service_config.rb
+++ b/lib/ecs_deploy/auto_scaler/service_config.rb
@@ -45,8 +45,9 @@ module EcsDeploy
           end
         end
 
-        if difference == 0 && desired_count > current_min_task_count
+        if desired_count > current_min_task_count
           downscale_triggers.each do |trigger|
+            next if difference > 0 && !trigger.prioritized_over_upscale_triggers?
             next unless trigger.match?
 
             @logger.info "#{log_prefix} Fire downscale trigger by #{trigger.alarm_name} #{trigger.state}"

--- a/lib/ecs_deploy/auto_scaler/trigger_config.rb
+++ b/lib/ecs_deploy/auto_scaler/trigger_config.rb
@@ -5,8 +5,18 @@ require "ecs_deploy/auto_scaler/config_base"
 
 module EcsDeploy
   module AutoScaler
-    TriggerConfig = Struct.new(:alarm_name, :region, :state, :step) do
+    TriggerConfig = Struct.new(:alarm_name, :region, :state, :step, :prioritized_over_upscale_triggers) do
       include ConfigBase
+
+      def match?
+        fetch_alarm.state_value == state
+      end
+
+      def prioritized_over_upscale_triggers?
+        !!prioritized_over_upscale_triggers
+      end
+
+      private
 
       def client
         Aws::CloudWatch::Client.new(
@@ -15,10 +25,6 @@ module EcsDeploy
           region: region,
           logger: logger
         )
-      end
-
-      def match?
-        fetch_alarm.state_value == state
       end
 
       def fetch_alarm


### PR DESCRIPTION
Increasing the desired count of some services is sometimes meaningless.
For example, we shouldn't increase the desired count of a service inserting records into a database in the background if the database is heavily loaded.
This new option is useful in such cases.
