### PR TITLE
Select terminate instances and suspend AZRebalance

### DIFF
--- a/lib/ecs_deploy/capistrano.rb
+++ b/lib/ecs_deploy/capistrano.rb
@@ -201,6 +201,7 @@ namespace :ecs do
             cluster: config[:cluster] || fetch(:ecs_default_cluster),
             auto_scaling_group_name: config[:auto_scaling_group_name],
             desired_capacity: config[:desired_capacity],
+            resume_az_rebalance: config[:resume_az_rebalance] || true,
             logger: logger
           )
           m.increase
@@ -222,6 +223,7 @@ namespace :ecs do
             cluster: config[:cluster] || fetch(:ecs_default_cluster),
             auto_scaling_group_name: config[:auto_scaling_group_name],
             desired_capacity: config[:desired_capacity],
+            resume_az_rebalance: config[:resume_az_rebalance] || true,
             logger: logger
           )
           m.decrease

--- a/lib/ecs_deploy/instance_fluctuation_manager.rb
+++ b/lib/ecs_deploy/instance_fluctuation_manager.rb
@@ -18,7 +18,7 @@ module EcsDeploy
     end
 
     def increase
-      asg = as_client.describe_auto_scaling_groups(auto_scaling_group_names: [@auto_scaling_group_name]).auto_scaling_groups.first
+      asg = fetch_auto_scaling_group
 
       @logger.info("Increase desired capacity of #{@auto_scaling_group_name}: #{asg.desired_capacity} => #{asg.max_size}")
       as_client.update_auto_scaling_group(auto_scaling_group_name: @auto_scaling_group_name, desired_capacity: asg.max_size)
@@ -39,7 +39,7 @@ module EcsDeploy
     end
 
     def decrease
-      asg = as_client.describe_auto_scaling_groups(auto_scaling_group_names: [@auto_scaling_group_name]).auto_scaling_groups.first
+      asg = fetch_auto_scaling_group
 
       decrease_count = asg.desired_capacity - @desired_capacity
       if decrease_count <= 0
@@ -113,6 +113,10 @@ module EcsDeploy
 
     def ecs_client
       @ecs_client ||= Aws::ECS::Client.new(aws_params)
+    end
+
+    def fetch_auto_scaling_group
+      as_client.describe_auto_scaling_groups(auto_scaling_group_names: [@auto_scaling_group_name]).auto_scaling_groups.first
     end
 
     # Extract container instances to terminate considering AZ balance


### PR DESCRIPTION
This PR is the starting point to fix the problem about terminating EC2 instance which has running tasks.

This PR includes following changes:
* Add more logs while increasing/decreasing EC2 instances
* Check terminating EC2 instances that are able to terminate
* Suspend AZRebalance while increasing/decreasing EC2 instances

See https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-suspend-resume-processes.html for more details about "Suspending and resuming scaling processes ".