### PR TITLE
Wait until stop old tasks

### DIFF
--- a/lib/ecs_deploy/instance_fluctuation_manager.rb
+++ b/lib/ecs_deploy/instance_fluctuation_manager.rb
@@ -19,7 +19,7 @@ module EcsDeploy
     end
 
     def increase
-      asg = as_client.describe_auto_scaling_groups(auto_scaling_group_names: [@auto_scaling_group_name]).auto_scaling_groups.first
+      asg = fetch_auto_scaling_group
 
       @logger.info("Increase desired capacity of #{@auto_scaling_group_name}: #{asg.desired_capacity} => #{asg.max_size}")
       as_client.update_auto_scaling_group(auto_scaling_group_name: @auto_scaling_group_name, desired_capacity: asg.max_size)
@@ -40,7 +40,7 @@ module EcsDeploy
     end
 
     def decrease
-      asg = as_client.describe_auto_scaling_groups(auto_scaling_group_names: [@auto_scaling_group_name]).auto_scaling_groups.first
+      asg = fetch_auto_scaling_group
 
       decrease_count = asg.desired_capacity - @desired_capacity
       if decrease_count <= 0
@@ -123,6 +123,10 @@ module EcsDeploy
 
     def ecs_client
       @ecs_client ||= Aws::ECS::Client.new(aws_params)
+    end
+
+    def fetch_auto_scaling_group
+      as_client.describe_auto_scaling_groups(auto_scaling_group_names: [@auto_scaling_group_name]).auto_scaling_groups.first
     end
 
     # Extract container instances to terminate considering AZ balance

--- a/lib/ecs_deploy/instance_fluctuation_manager.rb
+++ b/lib/ecs_deploy/instance_fluctuation_manager.rb
@@ -81,7 +81,7 @@ module EcsDeploy
       end
 
       stop_tasks_not_belonging_service(all_running_task_arns)
-      wait_until_stop_old_tasks(all_running_task_arns)
+      wait_until_tasks_stopped(all_running_task_arns)
 
       instance_ids = target_container_instances.map(&:ec2_instance_id)
       terminate_instances(instance_ids)
@@ -147,7 +147,7 @@ module EcsDeploy
       running_tasks_arn + stopped_running_task_arns
     end
 
-    def wait_until_stop_old_tasks(task_arns)
+    def wait_until_tasks_stopped(task_arns)
       @logger.info("All old tasks: #{task_arns.size}")
       task_arns.each_slice(MAX_DESCRIBABLE_ECS_TASK_COUNT).each do |arns|
         ecs_client.wait_until(:tasks_stopped, cluster: @cluster, tasks: arns)

--- a/lib/ecs_deploy/instance_fluctuation_manager.rb
+++ b/lib/ecs_deploy/instance_fluctuation_manager.rb
@@ -166,7 +166,7 @@ module EcsDeploy
       running_tasks = task_arns.each_slice(MAX_DESCRIBABLE_ECS_TASK_COUNT).flat_map do |arns|
         ecs_client.describe_tasks(cluster: @cluster, tasks: arns).tasks
       end.select do |task|
-        task.desired_status == "STOPPED" && task.last_status == "RUNNING"
+        task.desired_status == "RUNNING" || (task.desired_status == "STOPPED" && task.last_status == "RUNNING")
       end
 
       running_tasks.map(&:task_arn).each_slice(MAX_DESCRIBABLE_ECS_TASK_COUNT).each do |chunk|

--- a/lib/ecs_deploy/instance_fluctuation_manager.rb
+++ b/lib/ecs_deploy/instance_fluctuation_manager.rb
@@ -164,8 +164,6 @@ module EcsDeploy
           end
         end
       end
-      @logger.info("Tasks running on #{arn.split('/').last} will be stopped")
-      running_task_arns
     end
 
     def terminate_instances(instance_ids)

--- a/lib/ecs_deploy/instance_fluctuation_manager.rb
+++ b/lib/ecs_deploy/instance_fluctuation_manager.rb
@@ -152,13 +152,10 @@ module EcsDeploy
       end.select do |task|
         task.desired_status == "STOPPED" && task.last_status == "RUNNING"
       end
-      threads = []
+
       running_tasks.map(&:task_arn).each_slice(MAX_DESCRIBABLE_ECS_TASK_COUNT).each do |chunk|
-        threads << Thread.new(chunk) do |arns|
-          ecs_client.wait_until(:tasks_stopped, cluster: @cluster, tasks: arns)
-        end
+        ecs_client.wait_until(:tasks_stopped, cluster: @cluster, tasks: arns)
       end
-      threads.each(&:join)
       @logger.info("All old tasks are stopped")
     end
 

--- a/lib/ecs_deploy/instance_fluctuation_manager.rb
+++ b/lib/ecs_deploy/instance_fluctuation_manager.rb
@@ -180,7 +180,7 @@ module EcsDeploy
       @logger.info("Running tasks: #{running_task_arns.size}")
       unless running_task_arns.empty?
         running_task_arns.each_slice(MAX_DESCRIBABLE_ECS_TASK_COUNT).each do |arns|
-          ecs_client.describe_tasks(cluster: @cluster, tasks: arns).each do |task|
+          ecs_client.describe_tasks(cluster: @cluster, tasks: arns).tasks.each do |task|
             ecs_client.stop_task(cluster: @cluster, task: task.task_arn) if task.group.start_with?("family:")
           end
         end

--- a/lib/ecs_deploy/instance_fluctuation_manager.rb
+++ b/lib/ecs_deploy/instance_fluctuation_manager.rb
@@ -80,7 +80,7 @@ module EcsDeploy
         end
       end
 
-      stop_tasks(all_running_task_arns)
+      stop_tasks_not_belonging_service(all_running_task_arns)
       wait_until_stop_old_tasks(all_running_task_arns)
 
       instance_ids = target_container_instances.map(&:ec2_instance_id)
@@ -155,7 +155,7 @@ module EcsDeploy
       @logger.info("All old tasks are stopped")
     end
 
-    def stop_tasks(running_tasks)
+    def stop_tasks_not_belonging_service(running_tasks)
       @logger.info("Running tasks: #{running_task_arns.size}")
       unless running_task_arns.empty?
         running_task_arns.each_slice(MAX_DESCRIBABLE_ECS_TASK_COUNT).each do |arns|

--- a/lib/ecs_deploy/instance_fluctuation_manager.rb
+++ b/lib/ecs_deploy/instance_fluctuation_manager.rb
@@ -149,13 +149,7 @@ module EcsDeploy
 
     def wait_until_stop_old_tasks(task_arns)
       @logger.info("All old tasks: #{task_arns.size}")
-      running_tasks = task_arns.each_slice(MAX_DESCRIBABLE_ECS_TASK_COUNT).flat_map do |arns|
-        ecs_client.describe_tasks(cluster: @cluster, tasks: arns).tasks
-      end.select do |task|
-        task.desired_status == "RUNNING" || (task.desired_status == "STOPPED" && task.last_status == "RUNNING")
-      end
-
-      running_tasks.map(&:task_arn).each_slice(MAX_DESCRIBABLE_ECS_TASK_COUNT).each do |arns|
+      task_arns.each_slice(MAX_DESCRIBABLE_ECS_TASK_COUNT).each do |arns|
         ecs_client.wait_until(:tasks_stopped, cluster: @cluster, tasks: arns)
       end
       @logger.info("All old tasks are stopped")

--- a/lib/ecs_deploy/instance_fluctuation_manager.rb
+++ b/lib/ecs_deploy/instance_fluctuation_manager.rb
@@ -155,7 +155,7 @@ module EcsDeploy
       @logger.info("All old tasks are stopped")
     end
 
-    def stop_tasks_not_belonging_service(running_tasks)
+    def stop_tasks_not_belonging_service(running_task_arns)
       @logger.info("Running tasks: #{running_task_arns.size}")
       unless running_task_arns.empty?
         running_task_arns.each_slice(MAX_DESCRIBABLE_ECS_TASK_COUNT).each do |arns|

--- a/lib/ecs_deploy/instance_fluctuation_manager.rb
+++ b/lib/ecs_deploy/instance_fluctuation_manager.rb
@@ -8,7 +8,6 @@ module EcsDeploy
 
     MAX_UPDATABLE_ECS_CONTAINER_COUNT = 10
     MAX_DETACHEABLE_EC2_INSTACE_COUNT = 20
-    MAX_DESCRIBABLE_ECS_CONTAINER_COUNT = 100
     MAX_DESCRIBABLE_ECS_TASK_COUNT = 100
 
     def initialize(region:, cluster:, auto_scaling_group_name:, desired_capacity:, logger:)
@@ -50,13 +49,10 @@ module EcsDeploy
       end
       @logger.info("Decrease desired capacity of #{@auto_scaling_group_name}: #{asg.desired_capacity} => #{@desired_capacity}")
 
-      container_instance_arns = ecs_client.list_container_instances(
-        cluster: @cluster
-      ).flat_map(&:container_instance_arns)
-      container_instances = container_instance_arns.each_slice(MAX_DESCRIBABLE_ECS_CONTAINER_COUNT).flat_map do |arns|
+      container_instances = ecs_client.list_container_instances(cluster: @cluster).flat_map do |resp|
         ecs_client.describe_container_instances(
           cluster: @cluster,
-          container_instances: arns
+          container_instances: resp.container_instance_arns
         ).container_instances
       end
 

--- a/lib/ecs_deploy/instance_fluctuation_manager.rb
+++ b/lib/ecs_deploy/instance_fluctuation_manager.rb
@@ -76,10 +76,11 @@ module EcsDeploy
           status: "DRAINING"
         )
         arns.each do |arn|
-          all_running_task_arns.concat(stop_tasks(arn))
+          all_running_task_arns.concat(list_running_task_arns)
         end
       end
 
+      stop_tasks(all_running_task_arns)
       wait_until_stop_old_tasks(all_running_task_arns)
 
       instance_ids = target_container_instances.map(&:ec2_instance_id)
@@ -160,8 +161,7 @@ module EcsDeploy
       @logger.info("All old tasks are stopped")
     end
 
-    def stop_tasks(arn)
-      running_task_arns = list_running_task_arns(arn)
+    def stop_tasks(running_tasks)
       @logger.info("Running tasks: #{running_task_arns.size}")
       unless running_task_arns.empty?
         running_task_arns.each_slice(MAX_DESCRIBABLE_ECS_TASK_COUNT).each do |arns|

--- a/lib/ecs_deploy/instance_fluctuation_manager.rb
+++ b/lib/ecs_deploy/instance_fluctuation_manager.rb
@@ -76,7 +76,7 @@ module EcsDeploy
           status: "DRAINING"
         )
         arns.each do |arn|
-          all_running_task_arns.concat(list_running_task_arns)
+          all_running_task_arns.concat(list_running_task_arns(arn))
         end
       end
 

--- a/lib/ecs_deploy/instance_fluctuation_manager.rb
+++ b/lib/ecs_deploy/instance_fluctuation_manager.rb
@@ -169,7 +169,7 @@ module EcsDeploy
         task.desired_status == "RUNNING" || (task.desired_status == "STOPPED" && task.last_status == "RUNNING")
       end
 
-      running_tasks.map(&:task_arn).each_slice(MAX_DESCRIBABLE_ECS_TASK_COUNT).each do |chunk|
+      running_tasks.map(&:task_arn).each_slice(MAX_DESCRIBABLE_ECS_TASK_COUNT).each do |arns|
         ecs_client.wait_until(:tasks_stopped, cluster: @cluster, tasks: arns)
       end
       @logger.info("All old tasks are stopped")


### PR DESCRIPTION
In the previous version,

1. Update old tasks' state to "STOPPED" at the end of `ecs:deploy` task
2. In `EcsDeploy::InstanceFluctuationManager#decrease`, container instances that are in `DRAINING` status does not have any running tasks.
3. `wait_until(:tasks_stopped)` do nothing
4. Terminate EC2 instance while draining tasks
5. Tasks that take a long time to stop may be killed when terminating EC2 instance

In this version,

1. Update old tasks' state to "STOPPED" at the end of `ecs:deploy` task
2. Wait until tasks stopped properly after update container instance status to `DRAINING`
3. Terminate EC2 instances that have no running tasks

I've tested as followings:

Create resources using terraform using following main.tf:
```tf
provider "aws" {
  region = "ap-northeast-1"
}

resource "aws_placement_group" "okkez-sandbox" {
  name     = "okkez-sandbox"
  strategy = "cluster"
}

resource "aws_ecs_cluster" "okkez-sandbox-cluster" {
  name = "okkez-sandbox-cluster"
}

resource "aws_autoscaling_group" "okkez-sandbox" {
  name                      = "okkez-sandbox-asg"
  availability_zones        = ["ap-northeast-1a", "ap-northeast-1c"]
  max_size                  = 40
  min_size                  = 0
  health_check_grace_period = 300
  health_check_type         = "ELB"
  desired_capacity          = 0
  force_delete              = true
  launch_template {
    id      = aws_launch_template.okkez-sandbox.id
    version = "$Latest"
  }
}

resource "aws_launch_template" "okkez-sandbox" {
  name_prefix   = "okkez-sandbox-as"
  image_id      = "ami-0934e28fe3e390537"
  instance_type = "t2.micro"
  key_name      = "okkez-sandbox"
  # #!/bin/bash
  # echo ECS_CLUSTER=okkez-sandbox-cluster >> /etc/ecs/ecs.config
  # echo ECS_CONTAINER_STOP_TIMEOUT=1h >> /etc/ecs/ecs.config
  user_data =<<EOF
IyEvYmluL2Jhc2gKZWNobyBFQ1NfQ0xVU1RFUj1va2tlei1zYW5kYm94LWNsdXN0ZXIgPj4gL2V0
Yy9lY3MvZWNzLmNvbmZpZwplY2hvIEVDU19DT05UQUlORVJfU1RPUF9USU1FT1VUPTFoID4+IC9l
dGMvZWNzL2Vjcy5jb25maWcK
EOF

  iam_instance_profile {
    arn = "arn:aws:iam::xxxxxxxxxxxxxxx:instance-profile/ecsInstanceRole"
  } 
  vpc_security_group_ids = ["sg-xxxxxxxxxxxxxx"]

  tag_specifications {
    resource_type = "instance"

    tags = {
      Name = "okkez-sandbox"
    }
  }
  

  provisioner "local-exec" {
    command = "sleep 10"
  }
}
```

Dockerfile for okkez/sandbox:latest image
```
FROM ruby:2.7.1-slim-buster

COPY run.rb /run.rb
```

run.rb
```rb
require "json"
require "open-uri"

N = (ENV["N"] || "10").to_i
INTERVAL = (ENV["INTERVAL"] || "3").to_i
STDOUT.sync = true

def fetch_task_version
  version = "NONE"
  n = 0

  begin
    URI.open(ENV["ECS_CONTAINER_METADATA_URI"]) do |io|
      metadata = JSON.parse(io.read)
      version = metadata.dig("Labels", "com.amazonaws.ecs.task-definition-version")
    end

    return version
  rescue OpenURI::HTTPError => ex
    puts "#{ex.class} #{ex.message} #{n}"
    return "NONE" if n > 10
    n += 1
    sleep 2
    retry
  end
end

def graceful_stop(signal)
  #version = fetch_task_version
  puts "receive #{signal}"
  N.times do |n|
    sleep INTERVAL
    puts "#{$task_version} sleeping... #{n}"
  end
  puts "#{$task_version} exiting..."
  sleep INTERVAL
  exit
end

Signal.trap(:TERM) do
  graceful_stop(:TERM)
end
Signal.trap(:INT) do
  graceful_stop(:INT)
end

$task_version = fetch_task_version
puts "#{$task_version} start running..."
i = 0
loop do
  i += 1
  sleep 5
  puts "#{$task_version} processing something..." if (i % 10).zero?
end

```

deploy.rb
```ruby
lock "~> 3.14.1"

set :application, "my_app_name"
set :repo_url, "git@example.com:me/my_repo.git"

set :log_level, :debug

set :ecs_default_cluster, "okkez-sandbox-cluster"
set :ecs_region, %w(ap-northeast-1) # optional, if nil, use environment variable
set :ecs_wait_until_services_stable_max_attempts, 40 # optional
set :ecs_wait_until_services_stable_delay, 15 # optional

set :ecs_tasks, [
  {
    name: "okkez-sandbox-app",
    networkmode: "awsvpc",
    volumes: [
      {name: "socket_path", host: {}}
    ],
    container_definitions: [
      {
        name: "nginx",
        image: "nginx:1.17",
        cpu: 64,
        memory: 64,
        links: [],
        stop_timeout: 3600,
        port_mappings: [
          {container_port: 443, host_port: 443, protocol: "tcp"},
          {container_port: 80, host_port: 80, protocol: "tcp"}
        ],
        essential: true,
        environment: {},
        mount_points: [],
        volumes_from: [],
        log_configuration: {
          log_driver: "awslogs",
          options: {
            "awslogs-group": "/aws/ecs/okkez-sandbox",
            "awslogs-region": "ap-northeast-1",
            "awslogs-stream-prefix": "test-app",
            "awslogs-create-group": "true",
          }
        }
      },
      {
        name: "sandbox",
        image: "xxxxxxxxxxxx.dkr.ecr.ap-northeast-1.amazonaws.com/okkez/sandbox:latest",
        cpu: 128,
        memory: 128,
        stop_timeout: 3600,
        environment: [
          {name: "N", value: "30"},
          {name: "INTERVAL", value: "10"},
        ],
        links: [],
        essential: true,
        mount_points: [],
        volumes_from: [],
        depends_on: [
          { container_name: "nginx", condition: "START" }
        ],
        command: ["ruby", "-v", "/run.rb"],
        log_configuration: {
          log_driver: "awslogs",
          options: {
            "awslogs-group": "/aws/ecs/okkez-sandbox",
            "awslogs-region": "ap-northeast-1",
            "awslogs-stream-prefix": "test-app",
            "awslogs-create-group": "true",
          }
        }
      }
    ],
  }
]

set :ecs_services, [
  {
    name: "okkez-sandbox-app",
    desired_count: 20,
    deployment_configuration: {maximum_percent: 200, minimum_healthy_percent: 100},
  },
]

set :ecs_instance_fluctuation_manager_configs, [
  {
    region: "ap-northeast-1",
    cluster: "okkez-sandbox-cluster",
    auto_scaling_group_name: "okkez-sandbox-asg",
    desired_capacity: 20,
    resume_az_rebalance: true,
  }
]

task :dummy do
  30.times do |n|
    puts "Building docker image...#{n}"
    sleep 5
  end
end

before "deploy:updated", "dummy" # docker:build
after "deploy:updated", "ecs:deploy"
after "deploy:reverted", "ecs:rollback"
before "deploy:updating", "ecs:increase_instances_to_max_size"
after "deploy:finished", "ecs:terminate_redundant_instances"
after "deploy:failed", "ecs:terminate_redundant_instances"
```

