### PR TITLE
add option `enable_execute_command` to support ECS Exec

### DIFF
--- a/lib/ecs_deploy/capistrano.rb
+++ b/lib/ecs_deploy/capistrano.rb
@@ -108,6 +108,7 @@ namespace :ecs do
             enable_ecs_managed_tags: service[:enable_ecs_managed_tags],
             tags: service[:tags],
             propagate_tags: service[:propagate_tags],
+            enable_execute_command: service[:enable_execute_command],
           }
           service_options[:deployment_configuration] = service[:deployment_configuration] if service[:deployment_configuration]
           service_options[:placement_constraints] = service[:placement_constraints] if service[:placement_constraints]

--- a/lib/ecs_deploy/service.rb
+++ b/lib/ecs_deploy/service.rb
@@ -23,7 +23,8 @@ module EcsDeploy
       tags: nil,
       propagate_tags: nil,
       region: nil,
-      delete: false
+      delete: false,
+      enable_execute_command: false
     )
       @cluster = cluster
       @service_name = service_name
@@ -41,6 +42,7 @@ module EcsDeploy
       @enable_ecs_managed_tags = enable_ecs_managed_tags
       @tags = tags
       @propagate_tags = propagate_tags
+      @enable_execute_command = enable_execute_command
 
       @response = nil
 
@@ -64,6 +66,7 @@ module EcsDeploy
         deployment_configuration: @deployment_configuration,
         network_configuration: @network_configuration,
         health_check_grace_period_seconds: @health_check_grace_period_seconds,
+        enable_execute_command: @enable_execute_command,
       }
       if res.services.select{ |s| s.status == 'ACTIVE' }.empty?
         return if @delete


### PR DESCRIPTION
This PR add option `enable_execute_command` to support ECS Exec.

c.f. https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECS/Client.html#create_service-instance_method