### PR TITLE
Terminate instances whose status is not 'DEREGISTERING'

### DIFF
--- a/lib/ecs_deploy/instance_fluctuation_manager.rb
+++ b/lib/ecs_deploy/instance_fluctuation_manager.rb
@@ -56,6 +56,9 @@ module EcsDeploy
         ).container_instances
       end
 
+      # The status of ECS instances sometimes seems to remain 'DEREGISTERING' for a few minutes after they are terminated.
+      container_instances.reject! { |ci| ci.status == 'DEREGISTERING' }
+
       az_to_container_instances = container_instances.sort_by {|ci| - ci.running_tasks_count }.group_by do |ci|
         ci.attributes.find {|attribute| attribute.name == "ecs.availability-zone" }.value
       end

--- a/spec/ecs_deploy/instance_fluctuation_manager_spec.rb
+++ b/spec/ecs_deploy/instance_fluctuation_manager_spec.rb
@@ -279,5 +279,124 @@ RSpec.describe EcsDeploy::InstanceFluctuationManager do
         end
       end
     end
+
+    context "with DEREGISTERING status" do
+      let(:instance_fluctuation_manager) do
+        described_class.new(
+          region: "ap-northeast-1",
+          cluster: "cluster",
+          auto_scaling_group_name: "asg-cluster",
+          desired_capacity: 0,
+          logger: ::Logger.new(logdev)
+        )
+      end
+      let(:auto_scaling_groups) do
+        [
+          Aws::AutoScaling::Types::AutoScalingGroup.new(
+            desired_capacity: 1,
+            max_size: 5
+          )
+        ]
+      end
+      let(:arns) do
+        2.times.map { |i| "arn:aws:ecs:ap-northeast-1:xxx:container-instance/00#{i}" }
+      end
+      let(:ec2_instance_ids) do
+        2.times.map { |i| "ec2-#{arns[i]}" }
+      end
+      let(:container_instances) do
+        [
+          Aws::ECS::Types::ContainerInstance.new(
+            container_instance_arn: arns[0],
+            running_tasks_count: 1,
+            attributes: [Aws::ECS::Types::Attribute.new(name: "ecs.availability-zone", value: "zone-a")],
+            ec2_instance_id: ec2_instance_ids[0],
+            status: 'ACTIVE',
+          ),
+          Aws::ECS::Types::ContainerInstance.new(
+            container_instance_arn: arns[1],
+            running_tasks_count: 0,
+            attributes: [Aws::ECS::Types::Attribute.new(name: "ecs.availability-zone", value: "zone-a")],
+            ec2_instance_id: ec2_instance_ids[1],
+            status: 'DEREGISTERING',
+          )
+        ]
+      end
+      let(:task_arns) do
+        2.times.map {|i| sprintf("task-arn%02d", i) }
+      end
+      let(:tasks) do
+        task_arns.map do |arn|
+          group = ["family:#{arn}", "dummy:#{arn}"].sample
+          Aws::ECS::Types::Task.new(task_arn: arn, group: group)
+        end
+      end
+
+      before do
+        Aws.config[:autoscaling] = {
+          stub_responses: {
+            describe_auto_scaling_groups: lambda do |_|
+              Aws::AutoScaling::Types::AutoScalingGroupsType.new(
+                auto_scaling_groups: auto_scaling_groups,
+              )
+            end,
+            update_auto_scaling_group: lambda do |_|
+              # no error
+            end,
+            detach_instances: lambda do |_|
+              # no error
+            end
+          }
+        }
+
+        Aws.config[:ecs] = {
+          stub_responses: {
+            list_container_instances: lambda do |_|
+              Aws::ECS::Types::ListContainerInstancesResponse.new(container_instance_arns: arns)
+            end,
+            describe_container_instances: lambda do |_|
+              Aws::ECS::Types::DescribeContainerInstancesResponse.new(container_instances: container_instances)
+            end,
+            update_container_instances_state: lambda do |_|
+              # no error
+            end,
+            list_tasks: lambda do |_|
+              Aws::ECS::Types::ListTasksResponse.new(task_arns: task_arns)
+            end,
+            describe_tasks: lambda do |_|
+              Aws::ECS::Types::DescribeTasksResponse.new(tasks: tasks)
+            end,
+            stop_task: lambda do |_|
+              # no error
+            end
+          }
+        }
+        Aws.config[:ec2] = {
+          stub_responses: {
+            terminate_instances: {}
+          }
+        }
+
+        # Must stub after set :stub_responses to Aws.config[:ecs]
+        ecs_client = instance_fluctuation_manager.send(:ecs_client)
+        allow(ecs_client).to receive(:wait_until)
+        expect(ecs_client).to receive(:stop_task).at_most(2).times
+
+
+        ec2_client = instance_fluctuation_manager.send(:ec2_client)
+        allow(ec2_client).to receive(:wait_until)
+      end
+
+      it "succeeded in decreasing instances" do
+        # terminate instances whose status is not 'DEREGISTERING'
+        ec2_client = instance_fluctuation_manager.send(:ec2_client)
+        expect(ec2_client).to receive(:terminate_instances).with(instance_ids: [ec2_instance_ids[0]])
+
+        instance_fluctuation_manager.decrease
+        log = logdev.string
+        expect(log).to include("Decrease desired capacity of asg-cluster: 1 => 0")
+        expect(log).to include("Succeeded in decreasing instances!")
+      end
+    end
   end
 end


### PR DESCRIPTION
ecs_deploy sometimes tries to detach instances that are terminated already because the status of ECS instances seems to remain 'DEREGISTERING' for a few minutes after they are terminated.

`Aws::AutoScaling::Errors::ValidationError` error may occur in the following case.

```
Aws::AutoScaling::Errors::ValidationError: The instance i-xxxxxxxx is not part of Auto Scaling group ecs-xxxx.
```

1. `increase`
2. `decrease`
    - terminate redundant instances
3. `increase`
4. `decrease`
    - ecs_deploy tries to detach instances whose status is 'DEREGISTERING' but which are terminated at step 2.