### PR TITLE
Make draining feature opt-outable

### DIFF
--- a/lib/ecs_deploy/auto_scaler/auto_scaling_group_config.rb
+++ b/lib/ecs_deploy/auto_scaler/auto_scaling_group_config.rb
@@ -7,7 +7,7 @@ require "ecs_deploy/auto_scaler/cluster_resource_manager"
 
 module EcsDeploy
   module AutoScaler
-    AutoScalingGroupConfig = Struct.new(:name, :region, :cluster, :buffer, :service_configs) do
+    AutoScalingGroupConfig = Struct.new(:name, :region, :cluster, :buffer, :service_configs, :disable_draining) do
       include ConfigBase
 
       MAX_DETACHABLE_INSTANCE_COUNT = 20

--- a/lib/ecs_deploy/auto_scaler/instance_drainer.rb
+++ b/lib/ecs_deploy/auto_scaler/instance_drainer.rb
@@ -78,6 +78,11 @@ module EcsDeploy
       def set_instance_state_to_draining(config_to_instance_ids, region)
         cl = ecs_client(region)
         config_to_instance_ids.each do |config, instance_ids|
+          if config.disable_draining == true || config.disable_draining == "true"
+            @logger.info "Skip draining instances: region: #{region}, cluster: #{config.cluster}, instance_ids: #{instance_ids.inspect}"
+            next
+          end
+
           arns = cl.list_container_instances(
             cluster: config.cluster,
             filter: "ec2InstanceId in [#{instance_ids.join(",")}]",

--- a/lib/ecs_deploy/auto_scaler/spot_fleet_request_config.rb
+++ b/lib/ecs_deploy/auto_scaler/spot_fleet_request_config.rb
@@ -8,7 +8,7 @@ require "ecs_deploy/auto_scaler/cluster_resource_manager"
 
 module EcsDeploy
   module AutoScaler
-    SpotFleetRequestConfig = Struct.new(:id, :region, :cluster, :buffer, :service_configs) do
+    SpotFleetRequestConfig = Struct.new(:id, :region, :cluster, :buffer, :service_configs, :disable_draining) do
       include ConfigBase
 
       def initialize(attributes = {}, logger)


### PR DESCRIPTION
If we set ECS_ENABLE_SPOT_INSTANCE_DRAINING to true, both ecs-agent and autoscaler try to drain instances. As a result, instances don't seem to be drained on rare occasions. Disabling the draining feature with the new option "disable_drainig" resolves the issue.