### PR TITLE
Stop supporting ruby 2.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+    - name: Run tests
+      run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: ruby
-rvm:
-  - ruby-2.4.9
-  - ruby-2.5.7
-  - ruby-2.6.5

--- a/ecs_deploy.gemspec
+++ b/ecs_deploy.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", ">= 1.11", "< 3"
   spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rexml" # For aws-sdk-*
 end

--- a/lib/ecs_deploy/auto_scaler/cluster_resource_manager.rb
+++ b/lib/ecs_deploy/auto_scaler/cluster_resource_manager.rb
@@ -79,12 +79,10 @@ module EcsDeploy
           Timeout.timeout(180) do
             until @capacity == new_desired_capacity || (new_desired_capacity >= old_desired_capacity && @capacity > new_desired_capacity)
               @mutex.synchronize do
-                begin
-                  @capacity = calculate_active_instance_capacity
-                  @resource.broadcast
-                rescue => e
-                  AutoScaler.error_logger.warn("#{log_prefix} `#{__method__}': #{e} (#{e.class})")
-                end
+                @capacity = calculate_active_instance_capacity
+                @resource.broadcast
+              rescue => e
+                AutoScaler.error_logger.warn("#{log_prefix} `#{__method__}': #{e} (#{e.class})")
               end
 
               sleep interval


### PR DESCRIPTION
Because Ruby 2.4 is no longer maintained and we want to use a syntax it doesn't support.
cf. https://endoflife.date/ruby