### PR TITLE
Show service event logs while waiting for services

### DIFF
--- a/lib/ecs_deploy/service.rb
+++ b/lib/ecs_deploy/service.rb
@@ -182,7 +182,7 @@ module EcsDeploy
                 if s.deployments.size == 1 && s.running_count == s.desired_count
                   chunked_service_names.delete(s.service_name)
                 else
-                  service = ss.detect { _1.cluster == File.basename(s.cluster_arn) && _1.service_name == s.service_name }
+                  service = ss.detect {|sc| sc.cluster == File.basename(s.cluster_arn) && sc.service_name == s.service_name }
                   s.events.sort_by(&:created_at).each do |e|
                     next if e.created_at <= service.deploy_started_at
                     next if last_events[s.service_arn] && e.created_at <= last_events[s.service_arn].created_at

--- a/lib/ecs_deploy/service.rb
+++ b/lib/ecs_deploy/service.rb
@@ -191,7 +191,7 @@ module EcsDeploy
                 if s.deployments.size == 1 && s.running_count == s.desired_count
                   chunked_service_names.delete(s.service_name)
                 end
-                service = ss.detect {|sc| sc.cluster == File.basename(s.cluster_arn) && sc.service_name == s.service_name }
+                service = ss.detect {|sc| sc.service_name == s.service_name }
                 service.log_events(s)
               end
               break if chunked_service_names.empty?


### PR DESCRIPTION
Same as the title.

Sample logs are below:
Deploy 6 tasks in a service.
```console
❯ bundle exec cap production ecs:deploy
I, [2022-12-19T11:19:33.014312 #2660955]  INFO -- : register task definition [okkez-sandbox-app] [ap-northeast-1] [OK]
I, [2022-12-19T11:19:33.430797 #2660955]  INFO -- : update service [okkez-sandbox-app] [okkez-sandbox-cluster-2] [ap-northeast-1] [OK]
I, [2022-12-19T11:19:33.433077 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:19:48.479488 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:20:03.578139 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:20:03.807488 #2660955]  INFO -- : (service okkez-sandbox-app) has started 6 tasks: (task 908525d4911d4f03898ed7ea2ca80e08) (task f563c7a3357b4bc1853f649270f0eba2) (task dfdc03ed33324b8682d58b00
I, [2022-12-19T11:20:18.807742 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:20:33.936312 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:20:49.116221 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:21:04.221108 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:21:19.327127 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:21:34.452745 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:21:49.564441 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:22:04.671377 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:22:19.775371 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:22:34.881253 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:22:49.993029 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:23:05.266669 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:23:20.365033 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:23:35.560831 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:23:50.663871 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:24:05.865996 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:24:20.959714 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:24:36.232814 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:24:36.478192 #2660955]  INFO -- : (service okkez-sandbox-app, taskSet ecs-svc/6321210556304196096) has started 6 tasks: (task 6b990da6642a416899d1c7d54ca87e6c) (task 7e2f447e515645e090bf58665eb
I, [2022-12-19T11:24:51.478442 #2660955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
```
Deploy 6 tasks in a service again.
```console
❯ bundle exec cap production ecs:deploy
I, [2022-12-19T11:34:20.200512 #2670317]  INFO -- : register task definition [okkez-sandbox-app] [ap-northeast-1] [OK]
I, [2022-12-19T11:34:20.632720 #2670317]  INFO -- : update service [okkez-sandbox-app] [okkez-sandbox-cluster-2] [ap-northeast-1] [OK]
I, [2022-12-19T11:34:20.635369 #2670317]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:34:35.678439 #2670317]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:34:50.966810 #2670317]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:35:06.231458 #2670317]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:35:21.465842 #2670317]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:35:21.733438 #2670317]  INFO -- : (service okkez-sandbox-app) has stopped 6 running tasks: (task dfdc03ed33324b8682d58b0083048a43) (task 7e2f447e515645e090bf58665eb36204) (task c9a33494a51c43fd9837b50d25add8f4) (task f563c7a3357b4bc1853f649270f0eba2) (task 908525d4911d4f03898ed7ea2ca80e08) (task 6b990da6642a416899d1c7d54ca87e6c).
I, [2022-12-19T11:35:21.733536 #2670317]  INFO -- : (service okkez-sandbox-app) has started 6 tasks: (task 1b9b062ca2724cb0999bd94065bd8209) (task 272a8afa05d04c4f9c97fcac3f0b1f3b) (task 3f316f9b1f144b039a3ebf7e294a1ff9) (task 20d54d5f297348f9a684ad08da7f6c0d) (task f1a1806a602c405484a34784384b8f33) (task f7994e6ca75c4d55b8e55e233103eb04).
I, [2022-12-19T11:35:21.733581 #2670317]  INFO -- : (service okkez-sandbox-app, taskSet ecs-svc/0138548362422012048) has started 6 tasks: (task 1b9b062ca2724cb0999bd94065bd8209) (task 20d54d5f297348f9a684ad08da7f6c0d) (task 272a8afa05d04c4f9c97fcac3f0b1f3b) (task 3f316f9b1f144b039a3ebf7e294a1ff9) (task f1a1806a602c405484a34784384b8f33) (task f7994e6ca75c4d55b8e55e233103eb04).
I, [2022-12-19T11:35:36.733793 #2670317]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
```
Deploy 18 tasks in a service started with zero ECS instances.
```console
❯ bundle exec cap production ecs:deploy
I, [2022-12-19T11:55:28.657374 #2689955]  INFO -- : register task definition [okkez-sandbox-app] [ap-northeast-1] [OK]
I, [2022-12-19T11:55:29.123557 #2689955]  INFO -- : update service [okkez-sandbox-app] [okkez-sandbox-cluster-2] [ap-northeast-1] [OK]
I, [2022-12-19T11:55:29.127377 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:55:44.184601 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:55:59.431731 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:56:14.545784 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:56:14.652037 #2689955]  INFO -- : (service okkez-sandbox-app) has started 18 tasks: (task 7df6ae40847a4937b832705f0620546a) (task 8dab430ebd65400d9a4b282b59dcc949) (task ef8443657c25475088dce8913573b796) (task d311b014000c404ebf8dd2dd88fe5bf2) (task 9b0156bf669b414ab159e8a6762ba616) (task dd4eb23562fc4f2ab87a035b24039425) (task 33e0ffd13b414ebb9461dc67bfd1be7f) (task c8bcc03493ea4303a08492e341d01250) (task 4125cd08bdd846be81b54de07b59fc1b) (task 9c5fec158e814ff69d76422fbce5087b) (task 754d276c85d54ffd98f7d7911043b0d8) (task a6ae3874c8274cea83481adcf5797b6a) (task c4f70f44bd0844a4aba616f30ae58bb7) (task 5648c61e0f5449a08cb04db6914ea1e2) (task f72a13e21b784028952662c0eb3bc564) (task 79fc5fda79574b0bb3e053292d48b222) (task cd77279ffe54453fb5f0075f7504d989) (task 1c7a5a1853e04da082880dcfd39b48ee).
I, [2022-12-19T11:56:14.652149 #2689955]  INFO -- : (service okkez-sandbox-app, taskSet ecs-svc/9410614066452794398) has started 6 tasks: (task 1c7a5a1853e04da082880dcfd39b48ee) (task 33e0ffd13b414ebb9461dc67bfd1be7f) (task 4125cd08bdd846be81b54de07b59fc1b) (task 5648c61e0f5449a08cb04db6914ea1e2) (task 754d276c85d54ffd98f7d7911043b0d8) (task 79fc5fda79574b0bb3e053292d48b222).
I, [2022-12-19T11:56:29.652358 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:56:44.874503 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:56:59.991319 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:57:15.114308 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:57:30.229315 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:57:45.346405 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:58:00.457489 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:58:15.571488 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:58:30.675442 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:58:45.784179 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:59:00.896304 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:59:16.119781 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:59:31.223651 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:59:46.446419 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
I, [2022-12-19T11:59:46.670832 #2689955]  INFO -- : (service okkez-sandbox-app, taskSet ecs-svc/9410614066452794398) has started 12 tasks: (task 7df6ae40847a4937b832705f0620546a) (task 8dab430ebd65400d9a4b282b59dcc949) (task 9b0156bf669b414ab159e8a6762ba616) (task 9c5fec158e814ff69d76422fbce5087b) (task a6ae3874c8274cea83481adcf5797b6a) (task c4f70f44bd0844a4aba616f30ae58bb7) (task c8bcc03493ea4303a08492e341d01250) (task cd77279ffe54453fb5f0075f7504d989) (task d311b014000c404ebf8dd2dd88fe5bf2) (task dd4eb23562fc4f2ab87a035b24039425) (task ef8443657c25475088dce8913573b796) (task f72a13e21b784028952662c0eb3bc564).
I, [2022-12-19T12:00:01.671053 #2689955]  INFO -- : wait service stable [okkez-sandbox-app] [okkez-sandbox-cluster-2]
```