### PR TITLE
Merge `propagate_tags` to service_options when updating service

### DIFF
--- a/lib/ecs_deploy/service.rb
+++ b/lib/ecs_deploy/service.rb
@@ -110,6 +110,7 @@ module EcsDeploy
 
         service_options.merge!({service: @service_name})
         service_options.merge!({desired_count: @desired_count}) if @desired_count
+        service_options.merge!({propagate_tags: @propagate_tags}) if @propagate_tags
 
         current_service = res.services[0]
         service_options.merge!({force_new_deployment: true}) if need_force_new_deployment?(current_service)


### PR DESCRIPTION
The ecs_deploy supports `propagateTags` options when creating ECS Service, but doesn't support it when updating ECS Service. The UpdateService API supports `propagateTags`, so ecs_deploy supports too.

c.f. https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_UpdateService.html