### PR TITLE
enable retry_mode for ecs client

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ set :ecs_service_role, "customEcsServiceRole" # default: ecsServiceRole
 set :ecs_deploy_wait_timeout, 600 # default: 300
 set :ecs_wait_until_services_stable_max_attempts, 40 # optional
 set :ecs_wait_until_services_stable_delay, 15 # optional
-set :ecs_client_params, { retry_mode: "standard", max_attempts: 15 } # default: { retry_mode: "standard", max_attempts: 10 }
+set :ecs_client_params, { retry_mode: "standard", max_attempts: 10 } # default: {}
 
 set :ecs_tasks, [
   {

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ set :ecs_service_role, "customEcsServiceRole" # default: ecsServiceRole
 set :ecs_deploy_wait_timeout, 600 # default: 300
 set :ecs_wait_until_services_stable_max_attempts, 40 # optional
 set :ecs_wait_until_services_stable_delay, 15 # optional
+set :ecs_client_params, { retry_mode: "standard", max_attempts: 15 } # default: { retry_mode: "standard", max_attempts: 10 }
 
 set :ecs_tasks, [
   {

--- a/lib/ecs_deploy/capistrano.rb
+++ b/lib/ecs_deploy/capistrano.rb
@@ -10,6 +10,7 @@ namespace :ecs do
       c.default_region = Array(fetch(:ecs_region))[0] if fetch(:ecs_region)
       c.ecs_wait_until_services_stable_max_attempts = fetch(:ecs_wait_until_services_stable_max_attempts) if fetch(:ecs_wait_until_services_stable_max_attempts)
       c.ecs_wait_until_services_stable_delay = fetch(:ecs_wait_until_services_stable_delay) if fetch(:ecs_wait_until_services_stable_delay)
+      c.ecs_client_params = fetch(:ecs_client_params) if fetch(:ecs_client_params)
     end
 
     if ENV["TARGET_CLUSTER"]

--- a/lib/ecs_deploy/configuration.rb
+++ b/lib/ecs_deploy/configuration.rb
@@ -8,7 +8,8 @@ module EcsDeploy
       :deploy_wait_timeout,
       :ecs_service_role,
       :ecs_wait_until_services_stable_max_attempts,
-      :ecs_wait_until_services_stable_delay
+      :ecs_wait_until_services_stable_delay,
+      :ecs_client_params
 
     def initialize
       @log_level = :info
@@ -16,6 +17,7 @@ module EcsDeploy
       # The following values are the default values of Aws::ECS::Waiters::ServicesStable
       @ecs_wait_until_services_stable_max_attempts = 40
       @ecs_wait_until_services_stable_delay = 15
+      @ecs_client_params = { retry_mode: "standard", max_attempts: 10 }
     end
   end
 end

--- a/lib/ecs_deploy/configuration.rb
+++ b/lib/ecs_deploy/configuration.rb
@@ -17,7 +17,7 @@ module EcsDeploy
       # The following values are the default values of Aws::ECS::Waiters::ServicesStable
       @ecs_wait_until_services_stable_max_attempts = 40
       @ecs_wait_until_services_stable_delay = 15
-      @ecs_client_params = { retry_mode: "standard", max_attempts: 10 }
+      @ecs_client_params = {}
     end
   end
 end

--- a/lib/ecs_deploy/instance_fluctuation_manager.rb
+++ b/lib/ecs_deploy/instance_fluctuation_manager.rb
@@ -113,7 +113,7 @@ module EcsDeploy
     end
 
     def ecs_client
-      @ecs_client ||= Aws::ECS::Client.new(aws_params)
+      @ecs_client ||= Aws::ECS::Client.new(aws_params.merge(EcsDeploy.config.ecs_client_params))
     end
 
     def fetch_auto_scaling_group

--- a/lib/ecs_deploy/scheduled_task.rb
+++ b/lib/ecs_deploy/scheduled_task.rb
@@ -27,9 +27,10 @@ module EcsDeploy
       @platform_version = platform_version
       @group = group
       region ||= EcsDeploy.config.default_region
+      params ||= EcsDeploy.config.ecs_client_params
       @container_overrides = container_overrides
 
-      @client = region ? Aws::ECS::Client.new(region: region) : Aws::ECS::Client.new
+      @client = region ? Aws::ECS::Client.new(params.merge(region: region)) : Aws::ECS::Client.new(params)
       @region = @client.config.region
       @cloud_watch_events = Aws::CloudWatchEvents::Client.new(region: @region)
     end

--- a/lib/ecs_deploy/task_definition.rb
+++ b/lib/ecs_deploy/task_definition.rb
@@ -1,15 +1,9 @@
 module EcsDeploy
   class TaskDefinition
-    RETRY_BACKOFF = lambda do |c|
-      sleep(1)
-    end
-
-    RETRY_LIMIT = 10
-
     def self.deregister(arn, region: nil)
       region ||= EcsDeploy.config.default_region
-      param = {retry_backoff: RETRY_BACKOFF, retry_limit: RETRY_LIMIT}
-      client = region ? Aws::ECS::Client.new(param.merge(region: region)) : Aws::ECS::Client.new(param)
+      params ||= EcsDeploy.config.ecs_client_params
+      client = region ? Aws::ECS::Client.new(params.merge(region: region)) : Aws::ECS::Client.new(params)
       client.deregister_task_definition({
         task_definition: arn,
       })
@@ -29,6 +23,7 @@ module EcsDeploy
       @task_role_arn        = task_role_arn
       @execution_role_arn   = execution_role_arn
       region ||= EcsDeploy.config.default_region
+      params ||= EcsDeploy.config.ecs_client_params
 
       @container_definitions = container_definitions.map do |cd|
         if cd[:docker_labels]
@@ -46,8 +41,7 @@ module EcsDeploy
       @cpu = cpu&.to_s
       @memory = memory&.to_s
       @tags = tags
-      param = {retry_backoff: RETRY_BACKOFF, retry_limit: RETRY_LIMIT}
-      @client = region ? Aws::ECS::Client.new(param.merge(region: region)) : Aws::ECS::Client.new(param)
+      @client = region ? Aws::ECS::Client.new(params.merge(region: region)) : Aws::ECS::Client.new(params)
       @region = @client.config.region
     end
 


### PR DESCRIPTION
Set `retry_mode` for ECS Client for capistrano by default. And, add variable `ecs_client_retry_params` to override parameter of #initialize

- c.f.
  - https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html
  - https://docs.aws.amazon.com/ja_jp/sdk-for-ruby/v3/api/Aws/ECS/Client.html#initialize-instance_method