### PR TITLE
fix: make region fallback logic consistent in Capistrano tasks

### DIFF
--- a/lib/ecs_deploy/capistrano.rb
+++ b/lib/ecs_deploy/capistrano.rb
@@ -55,7 +55,7 @@ namespace :ecs do
   task deploy_scheduled_task: [:configure, :register_task_definition] do
     if fetch(:ecs_scheduled_tasks)
       regions = Array(fetch(:ecs_region))
-      regions = [nil] if regions.empty?
+      regions = [EcsDeploy.config.default_region] if regions.empty?
       regions.each do |r|
         fetch(:ecs_scheduled_tasks).each do |t|
           scheduled_task = EcsDeploy::ScheduledTask.new(
@@ -85,7 +85,7 @@ namespace :ecs do
   task deploy: [:configure, :register_task_definition] do
     if fetch(:ecs_services)
       regions = Array(fetch(:ecs_region))
-      regions = [nil] if regions.empty?
+      regions = [EcsDeploy.config.default_region] if regions.empty?
       regions.each do |r|
         services = fetch(:ecs_services).map do |service|
           if fetch(:target_cluster) && fetch(:target_cluster).size > 0
@@ -128,7 +128,7 @@ namespace :ecs do
   task rollback: [:configure] do
     if fetch(:ecs_services)
       regions = Array(fetch(:ecs_region))
-      regions = [nil] if regions.empty?
+      regions = [EcsDeploy.config.default_region] if regions.empty?
 
       rollback_routes = {}
       regions.each do |r|


### PR DESCRIPTION
I'm pretty sure right now this amounts to the same thing because of the way `c.default_region` is set (which means that `fetch(:ecs_region)` must be set, so the `if` here will never be true), but this should be consistent anyway so that if the logic for `c.default_region` does change it will properly matter for these tasks.