### PR TITLE
simplify args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 .rspec_status
 .envrc
+
+.claude/settings.local.json

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--format d

--- a/lib/ecs_deploy/scheduled_task.rb
+++ b/lib/ecs_deploy/scheduled_task.rb
@@ -7,28 +7,21 @@ module EcsDeploy
 
     attr_reader :cluster, :region, :schedule_rule_name
 
-    def initialize(
-      cluster:, rule_name:, schedule_expression:, enabled: true, description: nil, target_id: nil,
-      task_definition_name:, revision: nil, task_count: nil, role_arn:, network_configuration: nil, launch_type: nil, platform_version: nil, group: nil,
-      region: nil, container_overrides: nil
-    )
+    def initialize(cluster:, rule_name:, schedule_expression:, task_definition_name:, role_arn:, region: nil, **options)
       @cluster = cluster
       @rule_name = rule_name
       @schedule_expression = schedule_expression
-      @enabled = enabled
-      @description = description
-      @target_id = target_id || task_definition_name
       @task_definition_name = task_definition_name
-      @task_count = task_count || 1
-      @revision = revision
       @role_arn = role_arn
-      @network_configuration = network_configuration
-      @launch_type = launch_type || "EC2"
-      @platform_version = platform_version
-      @group = group
+
+      @options = options.dup
+      @options[:enabled] = @options.fetch(:enabled, true)
+      @options[:target_id] ||= task_definition_name
+      @options[:task_count] ||= 1
+      @options[:launch_type] ||= "EC2"
+
       region ||= EcsDeploy.config.default_region
       params ||= EcsDeploy.config.ecs_client_params
-      @container_overrides = container_overrides
 
       @client = region ? Aws::ECS::Client.new(params.merge(region: region)) : Aws::ECS::Client.new(params)
       @region = @client.config.region
@@ -50,7 +43,7 @@ module EcsDeploy
     end
 
     def task_definition_arn
-      suffix = @revision ? ":#{@revision}" : ""
+      suffix = @options[:revision] ? ":#{@options[:revision]}" : ""
       name = "#{@task_definition_name}#{suffix}"
       @client.describe_task_definition(task_definition: name).task_definition.task_definition_arn
     end
@@ -59,30 +52,25 @@ module EcsDeploy
       res = @cloud_watch_events.put_rule(
         name: @rule_name,
         schedule_expression: @schedule_expression,
-        state: @enabled ? "ENABLED" : "DISABLED",
-        description: @description,
+        state: @options[:enabled] ? "ENABLED" : "DISABLED",
+        description: @options[:description],
       )
       EcsDeploy.logger.info "created cloudwatch event rule [#{res.rule_arn}] [#{@region}] [#{Paint['OK', :green]}]"
     end
 
     def put_targets
       target = {
-        id: @target_id,
+        id: @options[:target_id],
         arn: cluster_arn,
         role_arn: @role_arn,
-        ecs_parameters: {
+        ecs_parameters: @options.except(:enabled, :description, :target_id, :revision, :container_overrides).merge(
           task_definition_arn: task_definition_arn,
-          task_count: @task_count,
-          network_configuration: @network_configuration,
-          launch_type: @launch_type,
-          platform_version: @platform_version,
-          group: @group,
-        },
+        ),
       }
       target[:ecs_parameters].compact!
 
-      if @container_overrides
-        target.merge!(input: { containerOverrides: @container_overrides }.to_json)
+      if @options[:container_overrides]
+        target.merge!(input: { containerOverrides: @options[:container_overrides] }.to_json)
       end
 
       res = @cloud_watch_events.put_targets(
@@ -90,7 +78,7 @@ module EcsDeploy
         targets: [target]
       )
       if res.failed_entry_count.zero?
-        EcsDeploy.logger.info "created cloudwatch event target [#{@target_id}] [#{@region}] [#{Paint['OK', :green]}]"
+        EcsDeploy.logger.info "created cloudwatch event target [#{@options[:target_id]}] [#{@region}] [#{Paint['OK', :green]}]"
       else
         res.failed_entries.each do |entry|
           EcsDeploy.logger.error "failed to create cloudwatch event target [#{@region}] target_id=#{entry.target_id} error_code=#{entry.error_code} error_message=#{entry.error_message}"

--- a/lib/ecs_deploy/service.rb
+++ b/lib/ecs_deploy/service.rb
@@ -9,42 +9,21 @@ module EcsDeploy
 
     attr_reader :cluster, :region, :service_name, :delete, :deploy_started_at
 
-    def initialize(
-      cluster:, service_name:, task_definition_name: nil, revision: nil,
-      load_balancers: nil,
-      desired_count: nil, deployment_configuration: {maximum_percent: 200, minimum_healthy_percent: 100},
-      launch_type: nil,
-      placement_constraints: [],
-      placement_strategy: [],
-      capacity_provider_strategy: nil,
-      network_configuration: nil,
-      health_check_grace_period_seconds: nil,
-      scheduling_strategy: 'REPLICA',
-      enable_ecs_managed_tags: nil,
-      tags: nil,
-      propagate_tags: nil,
-      region: nil,
-      delete: false,
-      enable_execute_command: false
-    )
+    # Immutable service properties that can only be set at creation time
+    CREATE_ONLY_KEYS = %i[launch_type scheduling_strategy].freeze
+
+    def initialize(cluster:, service_name:, region: nil, **options)
       @cluster = cluster
       @service_name = service_name
-      @task_definition_name = task_definition_name || service_name
-      @load_balancers = load_balancers
-      @desired_count = desired_count
-      @deployment_configuration = deployment_configuration
-      @launch_type = launch_type
-      @placement_constraints = placement_constraints
-      @placement_strategy = placement_strategy
-      @capacity_provider_strategy = capacity_provider_strategy
-      @network_configuration = network_configuration
-      @health_check_grace_period_seconds = health_check_grace_period_seconds
-      @scheduling_strategy = scheduling_strategy
-      @revision = revision
-      @enable_ecs_managed_tags = enable_ecs_managed_tags
-      @tags = tags
-      @propagate_tags = propagate_tags
-      @enable_execute_command = enable_execute_command
+      @options = options.dup
+      @task_definition_name = @options.delete(:task_definition_name) || service_name
+      @revision = @options.delete(:revision)
+      @delete = @options.delete(:delete) || false
+      @options[:deployment_configuration] ||= {maximum_percent: 200, minimum_healthy_percent: 100}
+      @options[:placement_constraints] ||= []
+      @options[:placement_strategy] ||= []
+      @options[:scheduling_strategy] ||= 'REPLICA'
+      @options[:enable_execute_command] ||= false
 
       @response = nil
 
@@ -52,8 +31,6 @@ module EcsDeploy
       params ||= EcsDeploy.config.ecs_client_params
       @client = region ? Aws::ECS::Client.new(params.merge(region: region)) : Aws::ECS::Client.new(params)
       @region = @client.config.region
-
-      @delete = delete
     end
 
     def current_task_definition_arn
@@ -64,75 +41,63 @@ module EcsDeploy
     def deploy
       @deploy_started_at = Time.now
       res = @client.describe_services(cluster: @cluster, services: [@service_name])
-      service_options = {
-        cluster: @cluster,
-        task_definition: task_definition_name_with_revision,
-        deployment_configuration: @deployment_configuration,
-        network_configuration: @network_configuration,
-        health_check_grace_period_seconds: @health_check_grace_period_seconds,
-        capacity_provider_strategy: @capacity_provider_strategy,
-        enable_execute_command: @enable_execute_command,
-        enable_ecs_managed_tags: @enable_ecs_managed_tags,
-        placement_constraints: @placement_constraints,
-        placement_strategy: @placement_strategy,
-      }
-
-      if @load_balancers && EcsDeploy.config.ecs_service_role
-        service_options.merge!({
-          role: EcsDeploy.config.ecs_service_role,
-        })
-      end
-
-      if @load_balancers
-        service_options.merge!({
-          load_balancers: @load_balancers,
-        })
-      end
 
       if res.services.select{ |s| s.status == 'ACTIVE' }.empty?
         return if @delete
-
-        service_options.merge!({
-          service_name: @service_name,
-          desired_count: @desired_count.to_i,
-          launch_type: @launch_type,
-          tags: @tags,
-          propagate_tags: @propagate_tags,
-        })
-
-        if @scheduling_strategy == 'DAEMON'
-          service_options[:scheduling_strategy] = @scheduling_strategy
-          service_options.delete(:desired_count)
-          service_options.delete(:placement_strategy)
-        end
-        @response = @client.create_service(service_options)
-        EcsDeploy.logger.info "created service [#{@service_name}] [#{@cluster}] [#{@region}] [#{Paint['OK', :green]}]"
+        create_service
       else
         return delete_service if @delete
-
-        service_options.merge!({service: @service_name})
-        service_options.merge!({desired_count: @desired_count}) if @desired_count
-        service_options.merge!({propagate_tags: @propagate_tags}) if @propagate_tags
-
-        current_service = res.services[0]
-        service_options.merge!({force_new_deployment: true}) if need_force_new_deployment?(current_service)
-
-        update_tags(@service_name, @tags)
-        if @scheduling_strategy == 'DAEMON'
-          service_options.delete(:placement_strategy)
-        end
-        @response = @client.update_service(service_options)
-        EcsDeploy.logger.info "updated service [#{@service_name}] [#{@cluster}] [#{@region}] [#{Paint['OK', :green]}]"
+        update_service(res.services[0])
       end
     end
 
+    private def create_service
+      service_options = @options.merge(
+        cluster: @cluster,
+        service_name: @service_name,
+        task_definition: task_definition_name_with_revision,
+      )
+      service_options[:desired_count] = service_options[:desired_count].to_i
+
+      if service_options[:load_balancers] && EcsDeploy.config.ecs_service_role
+        service_options[:role] = EcsDeploy.config.ecs_service_role
+      end
+
+      if service_options[:scheduling_strategy] == 'DAEMON'
+        service_options.delete(:desired_count)
+        service_options.delete(:placement_strategy)
+      end
+
+      @response = @client.create_service(service_options)
+      EcsDeploy.logger.info "created service [#{@service_name}] [#{@cluster}] [#{@region}] [#{Paint['OK', :green]}]"
+    end
+
+    private def update_service(current_service)
+      service_options = @options.except(*CREATE_ONLY_KEYS, :tags).merge(
+        cluster: @cluster,
+        service: @service_name,
+        task_definition: task_definition_name_with_revision,
+      )
+      service_options.delete(:desired_count) unless @options[:desired_count]
+      service_options.delete(:propagate_tags) unless @options[:propagate_tags]
+      service_options[:force_new_deployment] = true if need_force_new_deployment?(current_service)
+
+      update_tags(@service_name, @options[:tags])
+      if @options[:scheduling_strategy] == 'DAEMON'
+        service_options.delete(:placement_strategy)
+      end
+
+      @response = @client.update_service(service_options)
+      EcsDeploy.logger.info "updated service [#{@service_name}] [#{@cluster}] [#{@region}] [#{Paint['OK', :green]}]"
+    end
+
     private def need_force_new_deployment?(service)
-      return false unless @capacity_provider_strategy
+      return false unless @options[:capacity_provider_strategy]
       return true unless service.capacity_provider_strategy
 
-      return true if @capacity_provider_strategy.size != service.capacity_provider_strategy.size
+      return true if @options[:capacity_provider_strategy].size != service.capacity_provider_strategy.size
 
-      match_array = @capacity_provider_strategy.all? do |strategy|
+      match_array = @options[:capacity_provider_strategy].all? do |strategy|
         service.capacity_provider_strategy.find do |current_strategy|
           strategy[:capacity_provider] == current_strategy.capacity_provider &&
             strategy[:weight] == current_strategy.weight &&
@@ -144,7 +109,7 @@ module EcsDeploy
     end
 
     def delete_service
-      if @scheduling_strategy != 'DAEMON'
+      if @options[:scheduling_strategy] != 'DAEMON'
         @client.update_service(cluster: @cluster, service: @service_name, desired_count: 0)
         sleep 1
       end

--- a/lib/ecs_deploy/task_definition.rb
+++ b/lib/ecs_deploy/task_definition.rb
@@ -10,23 +10,19 @@ module EcsDeploy
       EcsDeploy.logger.info "deregistered task definition [#{arn}] [#{client.config.region}] [#{Paint['OK', :green]}]"
     end
 
-    def initialize(
-      task_definition_name:, region: nil,
-      network_mode: "bridge", volumes: [], container_definitions: [], placement_constraints: [],
-      task_role_arn: nil,
-      execution_role_arn: nil,
-      requires_compatibilities: nil,
-      cpu: nil, memory: nil,
-      tags: nil,
-      runtime_platform: {}
-    )
+    def initialize(task_definition_name:, region: nil, **options)
       @task_definition_name = task_definition_name
-      @task_role_arn        = task_role_arn
-      @execution_role_arn   = execution_role_arn
       region ||= EcsDeploy.config.default_region
       params ||= EcsDeploy.config.ecs_client_params
 
-      @container_definitions = container_definitions.map do |cd|
+      @options = options.dup
+      @options[:network_mode] ||= "bridge"
+      @options[:volumes] ||= []
+      @options[:container_definitions] ||= []
+      @options[:placement_constraints] ||= []
+      @options[:runtime_platform] ||= {}
+
+      @options[:container_definitions] = @options[:container_definitions].map do |cd|
         if cd[:docker_labels]
           cd[:docker_labels] = cd[:docker_labels].map { |k, v| [k.to_s, v] }.to_h
         end
@@ -35,16 +31,11 @@ module EcsDeploy
         end
         cd
       end
-      @volumes = volumes
-      @network_mode = network_mode
-      @placement_constraints = placement_constraints
-      @requires_compatibilities = requires_compatibilities
-      @cpu = cpu&.to_s
-      @memory = memory&.to_s
-      @tags = tags
+      @options[:cpu] = @options[:cpu]&.to_s
+      @options[:memory] = @options[:memory]&.to_s
+
       @client = region ? Aws::ECS::Client.new(params.merge(region: region)) : Aws::ECS::Client.new(params)
       @region = @client.config.region
-      @runtime_platform = runtime_platform
     end
 
     def recent_task_definition_arns
@@ -58,19 +49,9 @@ module EcsDeploy
     end
 
     def register
-      res = @client.register_task_definition({
-        family: @task_definition_name,
-        network_mode: @network_mode,
-        container_definitions: @container_definitions,
-        volumes: @volumes,
-        placement_constraints: @placement_constraints,
-        task_role_arn: @task_role_arn,
-        execution_role_arn: @execution_role_arn,
-        requires_compatibilities: @requires_compatibilities,
-        cpu: @cpu, memory: @memory,
-        tags: @tags,
-        runtime_platform: @runtime_platform
-      })
+      res = @client.register_task_definition(
+        @options.merge(family: @task_definition_name)
+      )
       EcsDeploy.logger.info "registered task definition [#{@task_definition_name}] [#{@region}] [#{Paint['OK', :green]}]"
       res.task_definition
     end

--- a/spec/ecs_deploy/instance_fluctuation_manager_spec.rb
+++ b/spec/ecs_deploy/instance_fluctuation_manager_spec.rb
@@ -23,8 +23,14 @@ RSpec.describe EcsDeploy::InstanceFluctuationManager do
       before do
         @auto_scaling_groups = [
           Aws::AutoScaling::Types::AutoScalingGroup.new(
+            auto_scaling_group_name: "asg-cluster",
             desired_capacity: 50,
-            max_size: 100
+            max_size: 100,
+            min_size: 0,
+            default_cooldown: 300,
+            availability_zones: ["ap-northeast-1a"],
+            health_check_type: "EC2",
+            created_time: Time.now,
           )
         ]
         Aws.config[:autoscaling] = {
@@ -35,21 +41,21 @@ RSpec.describe EcsDeploy::InstanceFluctuationManager do
               )
             end,
             update_auto_scaling_group: lambda do |_|
-              # no error
-              nil
+              {}
             end
           }
         }
 
-        cluster = Aws::ECS::Types::Cluster.new(registered_container_instances_count: 50)
-        expect(cluster).to receive(:registered_container_instances_count)
-          .exactly(5).times.and_return(60, 70, 80, 90, 100)
-        @clusters = [cluster]
         Aws.config[:ecs] = {
           stub_responses: {
-            describe_clusters: lambda do |_|
-              Aws::ECS::Types::DescribeClustersResponse.new(clusters: @clusters)
-            end
+            describe_clusters: [
+              Aws::ECS::Types::DescribeClustersResponse.new(clusters: [Aws::ECS::Types::Cluster.new(registered_container_instances_count: 50)]),
+              Aws::ECS::Types::DescribeClustersResponse.new(clusters: [Aws::ECS::Types::Cluster.new(registered_container_instances_count: 60)]),
+              Aws::ECS::Types::DescribeClustersResponse.new(clusters: [Aws::ECS::Types::Cluster.new(registered_container_instances_count: 70)]),
+              Aws::ECS::Types::DescribeClustersResponse.new(clusters: [Aws::ECS::Types::Cluster.new(registered_container_instances_count: 80)]),
+              Aws::ECS::Types::DescribeClustersResponse.new(clusters: [Aws::ECS::Types::Cluster.new(registered_container_instances_count: 90)]),
+              Aws::ECS::Types::DescribeClustersResponse.new(clusters: [Aws::ECS::Types::Cluster.new(registered_container_instances_count: 100)]),
+            ]
           }
         }
 
@@ -74,8 +80,14 @@ RSpec.describe EcsDeploy::InstanceFluctuationManager do
       before do
         @auto_scaling_groups = [
           Aws::AutoScaling::Types::AutoScalingGroup.new(
+            auto_scaling_group_name: "asg-cluster",
             desired_capacity: 100,
-            max_size: 100
+            max_size: 100,
+            min_size: 0,
+            default_cooldown: 300,
+            availability_zones: ["ap-northeast-1a"],
+            health_check_type: "EC2",
+            created_time: Time.now,
           )
         ]
         Aws.config[:autoscaling] = {
@@ -86,10 +98,10 @@ RSpec.describe EcsDeploy::InstanceFluctuationManager do
               )
             end,
             update_auto_scaling_group: lambda do |_|
-              # no error
+              {}
             end,
             detach_instances: lambda do |_|
-              # no error
+              {}
             end
           }
         }
@@ -121,7 +133,7 @@ RSpec.describe EcsDeploy::InstanceFluctuationManager do
               Aws::ECS::Types::DescribeContainerInstancesResponse.new(container_instances: container_instances)
             end,
             update_container_instances_state: lambda do |_|
-              # no error
+              {}
             end,
             list_tasks: lambda do |_|
               Aws::ECS::Types::ListTasksResponse.new(task_arns: task_arns)
@@ -130,7 +142,7 @@ RSpec.describe EcsDeploy::InstanceFluctuationManager do
               Aws::ECS::Types::DescribeTasksResponse.new(tasks: tasks)
             end,
             stop_task: lambda do |_|
-              # no error
+              {}
             end
           }
         }
@@ -153,7 +165,7 @@ RSpec.describe EcsDeploy::InstanceFluctuationManager do
         log = logdev.string
         expect(log).to include("Decreasing desired capacity of asg-cluster: 100 => 50")
         expect(log).to include("Succeeded in decreasing instances!")
-        instance_size_per_az = log.lines.grep(/AZ balance/).last.scan(/AZ balance: \{"zone-a"=>(\d+), "zone-b"=>(\d+)\}/).flatten.map(&:to_i)
+        instance_size_per_az = log.lines.grep(/AZ balance/).last.scan(/AZ balance: \{"zone-a"\s*=>\s*(\d+),\s*"zone-b"\s*=>\s*(\d+)\}/).flatten.map(&:to_i)
         expect(instance_size_per_az).to contain_exactly(25, 25)
       end
     end
@@ -162,8 +174,14 @@ RSpec.describe EcsDeploy::InstanceFluctuationManager do
       before do
         @auto_scaling_groups = [
           Aws::AutoScaling::Types::AutoScalingGroup.new(
+            auto_scaling_group_name: "asg-cluster",
             desired_capacity: 100,
-            max_size: 100
+            max_size: 100,
+            min_size: 0,
+            default_cooldown: 300,
+            availability_zones: ["ap-northeast-1a"],
+            health_check_type: "EC2",
+            created_time: Time.now,
           )
         ]
         Aws.config[:autoscaling] = {
@@ -174,10 +192,10 @@ RSpec.describe EcsDeploy::InstanceFluctuationManager do
               )
             end,
             update_auto_scaling_group: lambda do |_|
-              # no error
+              {}
             end,
             detach_instances: lambda do |_|
-              # no error
+              {}
             end
           }
         }
@@ -210,7 +228,7 @@ RSpec.describe EcsDeploy::InstanceFluctuationManager do
               Aws::ECS::Types::DescribeContainerInstancesResponse.new(container_instances: container_instances)
             end,
             update_container_instances_state: lambda do |_|
-              # no error
+              {}
             end,
             list_tasks: lambda do |_|
               Aws::ECS::Types::ListTasksResponse.new(task_arns: task_arns)
@@ -219,7 +237,7 @@ RSpec.describe EcsDeploy::InstanceFluctuationManager do
               Aws::ECS::Types::DescribeTasksResponse.new(tasks: tasks)
             end,
             stop_task: lambda do |_|
-              # no error
+              {}
             end
           }
         }
@@ -253,7 +271,7 @@ RSpec.describe EcsDeploy::InstanceFluctuationManager do
           log = logdev.string
           expect(log).to include("Decreasing desired capacity of asg-cluster: 100 => 60")
           expect(log).to include("Succeeded in decreasing instances!")
-          instance_size_per_az = log.lines.grep(/AZ balance/).last.scan(/AZ balance: \{"zone-a"=>(\d+), "zone-b"=>(\d+), "zone-c"=>(\d+)\}/).flatten.map(&:to_i)
+          instance_size_per_az = log.lines.grep(/AZ balance/).last.scan(/AZ balance: \{"zone-a"\s*=>\s*(\d+),\s*"zone-b"\s*=>\s*(\d+),\s*"zone-c"\s*=>\s*(\d+)\}/).flatten.map(&:to_i)
           expect(instance_size_per_az).to contain_exactly(20, 20, 20)
         end
       end
@@ -274,7 +292,7 @@ RSpec.describe EcsDeploy::InstanceFluctuationManager do
           log = logdev.string
           expect(log).to include("Decreasing desired capacity of asg-cluster: 100 => 53")
           expect(log).to include("Succeeded in decreasing instances!")
-          instance_size_per_az = log.lines.grep(/AZ balance/).last.scan(/AZ balance: \{"zone-a"=>(\d+), "zone-b"=>(\d+), "zone-c"=>(\d+)\}/).flatten.map(&:to_i)
+          instance_size_per_az = log.lines.grep(/AZ balance/).last.scan(/AZ balance: \{"zone-a"\s*=>\s*(\d+),\s*"zone-b"\s*=>\s*(\d+),\s*"zone-c"\s*=>\s*(\d+)\}/).flatten.map(&:to_i)
           expect(instance_size_per_az).to contain_exactly(17, 18, 18)
         end
       end
@@ -293,8 +311,14 @@ RSpec.describe EcsDeploy::InstanceFluctuationManager do
       let(:auto_scaling_groups) do
         [
           Aws::AutoScaling::Types::AutoScalingGroup.new(
+            auto_scaling_group_name: "asg-cluster",
             desired_capacity: 1,
-            max_size: 5
+            max_size: 5,
+            min_size: 0,
+            default_cooldown: 300,
+            availability_zones: ["ap-northeast-1a"],
+            health_check_type: "EC2",
+            created_time: Time.now,
           )
         ]
       end
@@ -341,10 +365,10 @@ RSpec.describe EcsDeploy::InstanceFluctuationManager do
               )
             end,
             update_auto_scaling_group: lambda do |_|
-              # no error
+              {}
             end,
             detach_instances: lambda do |_|
-              # no error
+              {}
             end
           }
         }
@@ -358,7 +382,7 @@ RSpec.describe EcsDeploy::InstanceFluctuationManager do
               Aws::ECS::Types::DescribeContainerInstancesResponse.new(container_instances: container_instances)
             end,
             update_container_instances_state: lambda do |_|
-              # no error
+              {}
             end,
             list_tasks: lambda do |_|
               Aws::ECS::Types::ListTasksResponse.new(task_arns: task_arns)
@@ -367,7 +391,7 @@ RSpec.describe EcsDeploy::InstanceFluctuationManager do
               Aws::ECS::Types::DescribeTasksResponse.new(tasks: tasks)
             end,
             stop_task: lambda do |_|
-              # no error
+              {}
             end
           }
         }


### PR DESCRIPTION
Relaxing method parameter restrictions to make it easier to keep up with changes to AWS APIs.