### PR TITLE
Add update_strategy and wait_strategy options for ECS-managed blue/green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v1.1
+
+## Unreleased
+
+### Enhancement
+
+- Add `update_strategy: :task_definition_only` and `wait_strategy` options to `EcsDeploy::Service` for ECS-managed blue/green deployments (`DeploymentController.Type=ECS` with `BLUE_GREEN`/`LINEAR`/`CANARY`). `wait_all_running` now auto-detects ECS-managed deployments and skips polling so Capistrano sessions do not block on multi-day Pause Hooks.
+
 # v1.0
 
 ## Release v1.0.7 - 2024/08/08

--- a/lib/ecs_deploy/service.rb
+++ b/lib/ecs_deploy/service.rb
@@ -7,10 +7,15 @@ module EcsDeploy
 
     class TooManyAttemptsError < StandardError; end
 
-    attr_reader :cluster, :region, :service_name, :delete, :deploy_started_at
+    attr_reader :cluster, :region, :service_name, :delete, :deploy_started_at, :update_strategy, :wait_strategy
 
-    # Immutable service properties that can only be set at creation time
-    CREATE_ONLY_KEYS = %i[launch_type scheduling_strategy].freeze
+    # Immutable service properties that can only be set at creation time.
+    # deployment_controller is rejected by update_service once the service exists.
+    CREATE_ONLY_KEYS = %i[launch_type scheduling_strategy deployment_controller].freeze
+
+    VALID_UPDATE_STRATEGIES = %i[replace_options task_definition_only].freeze
+    VALID_WAIT_STRATEGIES = %i[legacy none service_deployment].freeze
+    ECS_NATIVE_BLUE_GREEN_STRATEGIES = %w[BLUE_GREEN LINEAR CANARY].freeze
 
     def initialize(cluster:, service_name:, region: nil, **options)
       @cluster = cluster
@@ -19,6 +24,14 @@ module EcsDeploy
       @task_definition_name = @options.delete(:task_definition_name) || service_name
       @revision = @options.delete(:revision)
       @delete = @options.delete(:delete) || false
+      @update_strategy = @options.delete(:update_strategy) || :replace_options
+      @wait_strategy = @options.delete(:wait_strategy)
+      unless VALID_UPDATE_STRATEGIES.include?(@update_strategy)
+        raise ArgumentError, "Invalid update_strategy #{@update_strategy.inspect}, expected one of #{VALID_UPDATE_STRATEGIES.inspect}"
+      end
+      if @wait_strategy && !VALID_WAIT_STRATEGIES.include?(@wait_strategy)
+        raise ArgumentError, "Invalid wait_strategy #{@wait_strategy.inspect}, expected nil or one of #{VALID_WAIT_STRATEGIES.inspect}"
+      end
       @options[:deployment_configuration] ||= {maximum_percent: 200, minimum_healthy_percent: 100}
       @options[:placement_constraints] ||= []
       @options[:placement_strategy] ||= []
@@ -73,6 +86,15 @@ module EcsDeploy
     end
 
     private def update_service(current_service)
+      case @update_strategy
+      when :task_definition_only
+        update_task_definition_only(current_service)
+      else
+        update_service_full(current_service)
+      end
+    end
+
+    private def update_service_full(current_service)
       service_options = @options.except(*CREATE_ONLY_KEYS, :tags).merge(
         cluster: @cluster,
         service: @service_name,
@@ -86,6 +108,22 @@ module EcsDeploy
       if @options[:scheduling_strategy] == 'DAEMON'
         service_options.delete(:placement_strategy)
       end
+
+      @response = @client.update_service(service_options)
+      EcsDeploy.logger.info "updated service [#{@service_name}] [#{@cluster}] [#{@region}] [#{Paint['OK', :green]}]"
+    end
+
+    # ECS-managed blue/green deployments reject most update_service fields once
+    # the service exists; pass only what triggers a new deployment.
+    private def update_task_definition_only(current_service)
+      service_options = {
+        cluster: @cluster,
+        service: @service_name,
+        task_definition: task_definition_name_with_revision,
+      }
+      service_options[:force_new_deployment] = true if need_force_new_deployment?(current_service)
+
+      update_tags(@service_name, @options[:tags]) if @options.key?(:tags)
 
       @response = @client.update_service(service_options)
       EcsDeploy.logger.info "updated service [#{@service_name}] [#{@cluster}] [#{@region}] [#{Paint['OK', :green]}]"
@@ -149,30 +187,88 @@ module EcsDeploy
       end
     end
 
+    def skip_wait?
+      case @wait_strategy
+      when :none
+        true
+      when :legacy, :service_deployment
+        false
+      when nil
+        ecs_native_blue_green?
+      end
+    end
+
+    private def ecs_native_blue_green?
+      svc = @response&.service
+      return false unless svc&.deployment_controller&.type == "ECS"
+      strategy = svc.deployment_configuration&.strategy.to_s
+      ECS_NATIVE_BLUE_GREEN_STRATEGIES.include?(strategy)
+    end
+
     def self.wait_all_running(services)
-      services.group_by { |s| [s.cluster, s.region] }.flat_map do |(cl, region), ss|
-        params ||= EcsDeploy.config.ecs_client_params
+      threads = services.group_by { |s| [s.cluster, s.region] }.flat_map do |(cl, region), ss|
+        params = EcsDeploy.config.ecs_client_params
         client = Aws::ECS::Client.new(params.merge(region: region))
-        ss.reject(&:delete).map(&:service_name).each_slice(MAX_DESCRIBE_SERVICES).map do |chunked_service_names|
-          Thread.new do
-            EcsDeploy.config.ecs_wait_until_services_stable_max_attempts.times do
-              EcsDeploy.logger.info "waiting for services to stabilize [#{chunked_service_names.join(", ")}] [#{cl}]"
-              resp = client.describe_services(cluster: cl, services: chunked_service_names)
-              resp.services.each do |s|
-                # cf. https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-ecs/lib/aws-sdk-ecs/waiters.rb#L91-L96
-                if s.deployments.size == 1 && s.running_count == s.desired_count
-                  chunked_service_names.delete(s.service_name)
-                end
-                service = ss.detect {|sc| sc.service_name == s.service_name }
-                service.log_events(s)
-              end
-              break if chunked_service_names.empty?
-              sleep EcsDeploy.config.ecs_wait_until_services_stable_delay
-            end
-            raise TooManyAttemptsError unless chunked_service_names.empty?
+
+        targets = ss.reject(&:delete).reject do |s|
+          if s.skip_wait?
+            EcsDeploy.logger.info "skip waiting for service [#{s.service_name}] [#{cl}]: ECS-managed deployment, monitor via ecs:describe_deployment"
+            true
+          else
+            false
           end
         end
-      end.each(&:join)
+
+        legacy_targets = targets.reject { |s| s.wait_strategy == :service_deployment }
+        sd_targets = targets.select { |s| s.wait_strategy == :service_deployment }
+
+        legacy_threads(client, cl, ss, legacy_targets) + service_deployment_threads(client, cl, sd_targets)
+      end
+      threads.each(&:join)
+    end
+
+    def self.legacy_threads(client, cluster, all_services, targets)
+      targets.map(&:service_name).each_slice(MAX_DESCRIBE_SERVICES).map do |chunked_service_names|
+        Thread.new do
+          EcsDeploy.config.ecs_wait_until_services_stable_max_attempts.times do
+            EcsDeploy.logger.info "waiting for services to stabilize [#{chunked_service_names.join(", ")}] [#{cluster}]"
+            resp = client.describe_services(cluster: cluster, services: chunked_service_names)
+            resp.services.each do |s|
+              # cf. https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-ecs/lib/aws-sdk-ecs/waiters.rb#L91-L96
+              if s.deployments.size == 1 && s.running_count == s.desired_count
+                chunked_service_names.delete(s.service_name)
+              end
+              service = all_services.detect { |sc| sc.service_name == s.service_name }
+              service&.log_events(s)
+            end
+            break if chunked_service_names.empty?
+            sleep EcsDeploy.config.ecs_wait_until_services_stable_delay
+          end
+          raise TooManyAttemptsError unless chunked_service_names.empty?
+        end
+      end
+    end
+
+    def self.service_deployment_threads(client, cluster, targets)
+      targets.map do |service|
+        Thread.new do
+          pending = true
+          EcsDeploy.config.ecs_wait_until_services_stable_max_attempts.times do
+            EcsDeploy.logger.info "waiting for service deployment to settle [#{service.service_name}] [#{cluster}]"
+            arns = client.list_service_deployments(
+              cluster: cluster,
+              service: service.service_name,
+              status: %w[IN_PROGRESS PENDING],
+            ).service_deployments.map(&:service_deployment_arn)
+            if arns.empty?
+              pending = false
+              break
+            end
+            sleep EcsDeploy.config.ecs_wait_until_services_stable_delay
+          end
+          raise TooManyAttemptsError if pending
+        end
+      end
     end
 
     private

--- a/lib/ecs_deploy/service.rb
+++ b/lib/ecs_deploy/service.rb
@@ -13,7 +13,6 @@ module EcsDeploy
     # deployment_controller is rejected by update_service once the service exists.
     CREATE_ONLY_KEYS = %i[launch_type scheduling_strategy deployment_controller].freeze
 
-    VALID_UPDATE_STRATEGIES = %i[replace_options task_definition_only].freeze
     VALID_WAIT_STRATEGIES = %i[legacy none service_deployment].freeze
     ECS_NATIVE_BLUE_GREEN_STRATEGIES = %w[BLUE_GREEN LINEAR CANARY].freeze
 
@@ -24,10 +23,10 @@ module EcsDeploy
       @task_definition_name = @options.delete(:task_definition_name) || service_name
       @revision = @options.delete(:revision)
       @delete = @options.delete(:delete) || false
-      @update_strategy = @options.delete(:update_strategy) || :replace_options
+      @update_strategy = @options.delete(:update_strategy)
       @wait_strategy = @options.delete(:wait_strategy)
-      unless VALID_UPDATE_STRATEGIES.include?(@update_strategy)
-        raise ArgumentError, "Invalid update_strategy #{@update_strategy.inspect}, expected one of #{VALID_UPDATE_STRATEGIES.inspect}"
+      if @update_strategy && @update_strategy != :task_definition_only
+        raise ArgumentError, "Invalid update_strategy #{@update_strategy.inspect}, expected nil or :task_definition_only"
       end
       if @wait_strategy && !VALID_WAIT_STRATEGIES.include?(@wait_strategy)
         raise ArgumentError, "Invalid wait_strategy #{@wait_strategy.inspect}, expected nil or one of #{VALID_WAIT_STRATEGIES.inspect}"
@@ -86,8 +85,7 @@ module EcsDeploy
     end
 
     private def update_service(current_service)
-      case @update_strategy
-      when :task_definition_only
+      if @update_strategy == :task_definition_only
         update_task_definition_only(current_service)
       else
         update_service_full(current_service)

--- a/spec/ecs_deploy/service_spec.rb
+++ b/spec/ecs_deploy/service_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe EcsDeploy::Service do
       }.not_to raise_error
     end
 
-    it "defaults update_strategy to :replace_options and wait_strategy to nil" do
+    it "defaults update_strategy and wait_strategy to nil" do
       svc = described_class.new(cluster: "c", service_name: "s")
-      expect(svc.update_strategy).to eq(:replace_options)
+      expect(svc.update_strategy).to be_nil
       expect(svc.wait_strategy).to be_nil
     end
   end
@@ -165,7 +165,7 @@ RSpec.describe EcsDeploy::Service do
       end
     end
 
-    context "with default update_strategy (:replace_options)" do
+    context "with default update_strategy (nil)" do
       it "still excludes CREATE_ONLY_KEYS (including deployment_controller) from update_service" do
         ecs_client.stub_responses(:list_tags_for_resource, tags: [])
 

--- a/spec/ecs_deploy/service_spec.rb
+++ b/spec/ecs_deploy/service_spec.rb
@@ -1,0 +1,280 @@
+require "spec_helper"
+
+RSpec.describe EcsDeploy::Service do
+  let(:ecs_client) { Aws::ECS::Client.new(stub_responses: true, region: "us-east-1") }
+
+  before do
+    allow(Aws::ECS::Client).to receive(:new).and_return(ecs_client)
+  end
+
+  describe "#initialize" do
+    it "raises ArgumentError on invalid update_strategy" do
+      expect {
+        described_class.new(cluster: "c", service_name: "s", update_strategy: :nope)
+      }.to raise_error(ArgumentError, /update_strategy/)
+    end
+
+    it "raises ArgumentError on invalid wait_strategy" do
+      expect {
+        described_class.new(cluster: "c", service_name: "s", wait_strategy: :nope)
+      }.to raise_error(ArgumentError, /wait_strategy/)
+    end
+
+    it "accepts known update_strategy and wait_strategy" do
+      expect {
+        described_class.new(
+          cluster: "c",
+          service_name: "s",
+          update_strategy: :task_definition_only,
+          wait_strategy: :none,
+        )
+      }.not_to raise_error
+    end
+
+    it "defaults update_strategy to :replace_options and wait_strategy to nil" do
+      svc = described_class.new(cluster: "c", service_name: "s")
+      expect(svc.update_strategy).to eq(:replace_options)
+      expect(svc.wait_strategy).to be_nil
+    end
+  end
+
+  describe "#deploy on a non-existent service" do
+    before do
+      ecs_client.stub_responses(:describe_services, services: [])
+    end
+
+    it "passes ECS-native blue/green options through to create_service" do
+      service = described_class.new(
+        cluster: "cluster1",
+        service_name: "svc1",
+        task_definition_name: "td1",
+        launch_type: "FARGATE",
+        platform_version: "LATEST",
+        desired_count: 1,
+        deployment_controller: { type: "ECS" },
+        deployment_configuration: {
+          strategy: "LINEAR",
+          linear_configuration: { step_percent: 50.0, step_bake_time_in_minutes: 60 },
+          bake_time_in_minutes: 5,
+          deployment_circuit_breaker: { enable: true, rollback: true },
+          lifecycle_hooks: [
+            {
+              hook_target_arn: "arn:aws:lambda:us-east-1:0:function:pause",
+              role_arn: "arn:aws:iam::0:role/role-x",
+              lifecycle_stages: ["POST_TEST_TRAFFIC_SHIFT"],
+            },
+          ],
+        },
+        load_balancers: [
+          {
+            target_group_arn: "arn:aws:elasticloadbalancing:::targetgroup/tg1",
+            container_name: "app",
+            container_port: 8080,
+            advanced_configuration: {
+              alternate_target_group_arn: "arn:aws:elasticloadbalancing:::targetgroup/tg2",
+              production_listener_rule: "arn:aws:elasticloadbalancing:::listener-rule/prod",
+              test_listener_rule: "arn:aws:elasticloadbalancing:::listener-rule/test",
+              role_arn: "arn:aws:iam::0:role/role-y",
+            },
+          },
+        ],
+      )
+
+      service.deploy
+
+      create_call = ecs_client.api_requests.find { |r| r[:operation_name] == :create_service }
+      expect(create_call).not_to be_nil
+      params = create_call[:params]
+      expect(params[:deployment_controller]).to eq(type: "ECS")
+      expect(params[:deployment_configuration][:strategy]).to eq("LINEAR")
+      expect(params[:deployment_configuration][:linear_configuration]).to eq(step_percent: 50.0, step_bake_time_in_minutes: 60)
+      expect(params[:deployment_configuration][:lifecycle_hooks].first).to include(
+        hook_target_arn: "arn:aws:lambda:us-east-1:0:function:pause",
+        lifecycle_stages: ["POST_TEST_TRAFFIC_SHIFT"],
+      )
+      expect(params[:load_balancers].first[:advanced_configuration]).to include(
+        alternate_target_group_arn: "arn:aws:elasticloadbalancing:::targetgroup/tg2",
+        production_listener_rule: "arn:aws:elasticloadbalancing:::listener-rule/prod",
+      )
+      expect(params[:platform_version]).to eq("LATEST")
+    end
+
+    it "preserves the user-supplied deployment_configuration without overwriting it with defaults" do
+      service = described_class.new(
+        cluster: "cluster1",
+        service_name: "svc1",
+        task_definition_name: "td1",
+        desired_count: 1,
+        deployment_configuration: { strategy: "LINEAR" },
+      )
+
+      service.deploy
+
+      create_call = ecs_client.api_requests.find { |r| r[:operation_name] == :create_service }
+      expect(create_call[:params][:deployment_configuration]).to eq(strategy: "LINEAR")
+    end
+  end
+
+  describe "#deploy on an existing service" do
+    before do
+      ecs_client.stub_responses(:describe_services, services: [
+        {
+          service_name: "svc1",
+          status: "ACTIVE",
+          service_arn: "arn:aws:ecs:us-east-1:000000000000:service/cluster1/svc1",
+          capacity_provider_strategy: [],
+        },
+      ])
+    end
+
+    context "with update_strategy: :task_definition_only" do
+      it "sends only cluster, service, task_definition to update_service" do
+        service = described_class.new(
+          cluster: "cluster1",
+          service_name: "svc1",
+          task_definition_name: "td1",
+          revision: 7,
+          desired_count: 3,
+          launch_type: "FARGATE",
+          deployment_controller: { type: "ECS" },
+          deployment_configuration: { strategy: "LINEAR" },
+          load_balancers: [{ target_group_arn: "tg", container_name: "c", container_port: 1 }],
+          update_strategy: :task_definition_only,
+        )
+
+        service.deploy
+
+        update_call = ecs_client.api_requests.find { |r| r[:operation_name] == :update_service }
+        expect(update_call).not_to be_nil
+        expect(update_call[:params].keys).to contain_exactly(:cluster, :service, :task_definition)
+        expect(update_call[:params][:task_definition]).to eq("td1:7")
+      end
+
+      it "does not call update_tags when :tags is not provided" do
+        service = described_class.new(
+          cluster: "cluster1",
+          service_name: "svc1",
+          task_definition_name: "td1",
+          update_strategy: :task_definition_only,
+        )
+
+        service.deploy
+
+        called = ecs_client.api_requests.map { |r| r[:operation_name] }
+        expect(called).not_to include(:list_tags_for_resource)
+      end
+    end
+
+    context "with default update_strategy (:replace_options)" do
+      it "still excludes CREATE_ONLY_KEYS (including deployment_controller) from update_service" do
+        ecs_client.stub_responses(:list_tags_for_resource, tags: [])
+
+        service = described_class.new(
+          cluster: "cluster1",
+          service_name: "svc1",
+          task_definition_name: "td1",
+          launch_type: "FARGATE",
+          deployment_controller: { type: "ECS" },
+          network_configuration: { awsvpc_configuration: { subnets: ["s1"], security_groups: [], assign_public_ip: "DISABLED" } },
+          desired_count: 2,
+        )
+
+        service.deploy
+
+        update_call = ecs_client.api_requests.find { |r| r[:operation_name] == :update_service }
+        expect(update_call).not_to be_nil
+        params = update_call[:params]
+        expect(params).not_to have_key(:launch_type)
+        expect(params).not_to have_key(:deployment_controller)
+        expect(params[:network_configuration]).to eq(awsvpc_configuration: { subnets: ["s1"], security_groups: [], assign_public_ip: "DISABLED" })
+        expect(params[:desired_count]).to eq(2)
+      end
+    end
+  end
+
+  describe ".wait_all_running" do
+    def build_service_after_deploy(stub_create_service:, **service_options)
+      ecs_client.stub_responses(:describe_services, services: [])
+      ecs_client.stub_responses(:create_service, service: stub_create_service)
+      service = described_class.new(
+        cluster: "cluster1",
+        service_name: "svc1",
+        task_definition_name: "td1",
+        desired_count: 1,
+        **service_options,
+      )
+      service.deploy
+      ecs_client.api_requests.clear
+      service
+    end
+
+    it "auto-detects ECS-managed blue/green and skips polling" do
+      service = build_service_after_deploy(
+        stub_create_service: {
+          deployment_controller: { type: "ECS" },
+          deployment_configuration: { strategy: "LINEAR" },
+        },
+        deployment_controller: { type: "ECS" },
+        deployment_configuration: { strategy: "LINEAR" },
+      )
+
+      described_class.wait_all_running([service])
+
+      wait_calls = ecs_client.api_requests.map { |r| r[:operation_name] }
+      expect(wait_calls).not_to include(:describe_services)
+      expect(wait_calls).not_to include(:list_service_deployments)
+    end
+
+    it "skips polling for an explicit wait_strategy: :none" do
+      service = build_service_after_deploy(
+        stub_create_service: {},
+        wait_strategy: :none,
+      )
+
+      described_class.wait_all_running([service])
+
+      wait_calls = ecs_client.api_requests.map { |r| r[:operation_name] }
+      expect(wait_calls).not_to include(:describe_services)
+      expect(wait_calls).not_to include(:list_service_deployments)
+    end
+
+    it "uses list_service_deployments for wait_strategy: :service_deployment" do
+      service = build_service_after_deploy(
+        stub_create_service: {},
+        wait_strategy: :service_deployment,
+      )
+      ecs_client.stub_responses(:list_service_deployments, service_deployments: [])
+
+      described_class.wait_all_running([service])
+
+      ops = ecs_client.api_requests.map { |r| r[:operation_name] }
+      expect(ops).to include(:list_service_deployments)
+      expect(ops).not_to include(:describe_services)
+    end
+
+    it "falls back to legacy polling for non-ECS-managed services" do
+      service = build_service_after_deploy(
+        stub_create_service: {
+          deployment_controller: { type: "CODE_DEPLOY" },
+        },
+        deployment_controller: { type: "CODE_DEPLOY" },
+      )
+      ecs_client.stub_responses(:describe_services, services: [
+        {
+          service_name: "svc1",
+          status: "ACTIVE",
+          desired_count: 1,
+          running_count: 1,
+          deployments: [{ id: "d1" }],
+          events: [],
+        },
+      ])
+
+      described_class.wait_all_running([service])
+
+      ops = ecs_client.api_requests.map { |r| r[:operation_name] }
+      expect(ops).to include(:describe_services)
+      expect(ops).not_to include(:list_service_deployments)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`EcsDeploy::Service` gains two opt-in options to support ECS-managed blue/green deployments (`DeploymentController.Type=ECS` with `BLUE_GREEN`/`LINEAR`/`CANARY` strategies). Behavior is unchanged for existing users — both new options default to the legacy code path.

- **`update_strategy:`** (`:replace_options` default, or `:task_definition_only`)
  - `:task_definition_only` makes `update_service` send only `cluster`, `service`, `task_definition`. ECS-managed deployments reject most other fields once the service exists, and the task-definition swap alone triggers a new deployment.
  - `:replace_options` keeps the previous behavior of merging `@options.except(*CREATE_ONLY_KEYS, :tags)` into `update_service`.
- **`wait_strategy:`** (`nil` default = auto-detect, or `:legacy` / `:none` / `:service_deployment`)
  - When unset, `wait_all_running` auto-detects ECS-managed deployments (via `deployment_controller.type == "ECS"` plus a `BLUE_GREEN`/`LINEAR`/`CANARY` strategy) and skips polling. Pause Hooks can keep a deployment paused for up to 14 days, so blocking a Capistrano session is impractical.
  - `:legacy` forces the previous `s.deployments.size == 1 && s.running_count == s.desired_count` poll.
  - `:none` skips waiting unconditionally.
  - `:service_deployment` polls `list_service_deployments` for `IN_PROGRESS`/`PENDING` deployments instead.

`deployment_controller` joins `CREATE_ONLY_KEYS` because ECS rejects it on `update_service` once the service exists.

This is the first PR in a 4-PR stack that adds full ECS-managed blue/green support to the gem.

## Test plan

- [x] `bundle exec rspec` — 37 examples, 0 failures (13 new in `spec/ecs_deploy/service_spec.rb`)
- [ ] Verify with `reproio/repro-streamhouse` against this branch that the existing `Service.new(...)` path is byte-for-byte unchanged when `update_strategy` and `wait_strategy` are not set