### PR TITLE
Pass the whole service hash through ecs:deploy to EcsDeploy::Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking change
+
+- `ecs:deploy` capistrano task now passes the entire service hash through to `EcsDeploy::Service.new` instead of forwarding an explicit allow-list of keys. New SDK fields (e.g. `deployment_controller`, `platform_version`, `service_connect_configuration`, `volume_configurations`, `availability_zone_rebalancing`, `load_balancers[].advanced_configuration`) are supported automatically without gem updates. Any custom non-SDK keys previously placed in `set :ecs_services` entries will now reach the SDK and may cause errors — remove or rename them.
+
 ### Enhancement
 
 - Add `update_strategy: :task_definition_only` and `wait_strategy` options to `EcsDeploy::Service` for ECS-managed blue/green deployments (`DeploymentController.Type=ECS` with `BLUE_GREEN`/`LINEAR`/`CANARY`). `wait_all_running` now auto-detects ECS-managed deployments and skips polling so Capistrano sessions do not block on multi-day Pause Hooks.

--- a/lib/ecs_deploy/capistrano.rb
+++ b/lib/ecs_deploy/capistrano.rb
@@ -96,31 +96,15 @@ namespace :ecs do
             next unless fetch(:target_task_definition).include?(service[:task_definition_name])
           end
 
-          service_options = {
-            region: r,
-            cluster: service[:cluster] || fetch(:ecs_default_cluster),
-            service_name: service[:name],
-            task_definition_name: service[:task_definition_name],
-            load_balancers: service[:load_balancers],
-            desired_count: service[:desired_count],
-            launch_type: service[:launch_type],
-            network_configuration: service[:network_configuration],
-            health_check_grace_period_seconds: service[:health_check_grace_period_seconds],
-            delete: service[:delete],
-            enable_ecs_managed_tags: service[:enable_ecs_managed_tags],
-            tags: service[:tags],
-            propagate_tags: service[:propagate_tags],
-            enable_execute_command: service[:enable_execute_command],
-          }
-          service_options[:deployment_configuration] = service[:deployment_configuration] if service[:deployment_configuration]
-          service_options[:placement_constraints] = service[:placement_constraints] if service[:placement_constraints]
-          service_options[:placement_strategy] = service[:placement_strategy] if service[:placement_strategy]
-          service_options[:capacity_provider_strategy] = service[:capacity_provider_strategy] if service[:capacity_provider_strategy]
-          service_options[:scheduling_strategy] = service[:scheduling_strategy] if service[:scheduling_strategy]
+          service_options = service.dup
+          service_options[:service_name] = service_options.delete(:name) if service_options.key?(:name)
+          service_options[:cluster] ||= fetch(:ecs_default_cluster)
+          service_options[:region] = r
+
           s = EcsDeploy::Service.new(**service_options)
           s.deploy
           s
-        end
+        end.compact
         EcsDeploy::Service.wait_all_running(services)
       end
     end

--- a/spec/ecs_deploy/capistrano_spec.rb
+++ b/spec/ecs_deploy/capistrano_spec.rb
@@ -1,0 +1,115 @@
+require "spec_helper"
+require "rake"
+
+module CapistranoStub
+  def fetch(key, default = nil)
+    settings = Thread.current[:capistrano_settings] || {}
+    settings.fetch(key, default)
+  end
+
+  def set(key, value)
+    Thread.current[:capistrano_settings] ||= {}
+    Thread.current[:capistrano_settings][key] = value
+  end
+end
+
+Object.include(CapistranoStub)
+
+RSpec.describe "ecs:deploy capistrano task" do
+  before(:all) do
+    Rake.application = Rake::Application.new
+    load File.expand_path("../../lib/ecs_deploy/capistrano.rb", __dir__)
+  end
+
+  before do
+    Thread.current[:capistrano_settings] = {
+      ecs_default_cluster: "default-cluster",
+      ecs_region: "us-east-1",
+    }
+    Rake::Task["ecs:configure"].clear_actions
+    Rake::Task["ecs:register_task_definition"].clear_actions
+    Rake::Task["ecs:configure"].reenable
+    Rake::Task["ecs:register_task_definition"].reenable
+    Rake::Task["ecs:deploy"].reenable
+    allow(EcsDeploy::Service).to receive(:wait_all_running)
+  end
+
+  after do
+    Thread.current[:capistrano_settings] = nil
+  end
+
+  it "passes the whole service hash through to EcsDeploy::Service.new" do
+    Thread.current[:capistrano_settings][:ecs_services] = [
+      {
+        name: "svc1",
+        task_definition_name: "td1",
+        deployment_controller: { type: "ECS" },
+        deployment_configuration: { strategy: "LINEAR" },
+        load_balancers: [{ advanced_configuration: { production_listener_rule: "rule-prod" } }],
+        update_strategy: :task_definition_only,
+        wait_strategy: :none,
+        foo_bar_baz: "future-sdk-field",
+      },
+    ]
+
+    received_kwargs = nil
+    fake_service = instance_double(EcsDeploy::Service, deploy: nil)
+    allow(EcsDeploy::Service).to receive(:new) do |**kwargs|
+      received_kwargs = kwargs
+      fake_service
+    end
+
+    Rake::Task["ecs:deploy"].invoke
+
+    expect(received_kwargs).to include(
+      service_name: "svc1",
+      task_definition_name: "td1",
+      deployment_controller: { type: "ECS" },
+      deployment_configuration: { strategy: "LINEAR" },
+      load_balancers: [{ advanced_configuration: { production_listener_rule: "rule-prod" } }],
+      update_strategy: :task_definition_only,
+      wait_strategy: :none,
+      foo_bar_baz: "future-sdk-field",
+      cluster: "default-cluster",
+      region: "us-east-1",
+    )
+    expect(received_kwargs).not_to have_key(:name)
+  end
+
+  it "preserves explicit :cluster instead of overriding with default" do
+    Thread.current[:capistrano_settings][:ecs_services] = [
+      { name: "svc1", task_definition_name: "td1", cluster: "explicit-cluster" },
+    ]
+
+    received_kwargs = nil
+    allow(EcsDeploy::Service).to receive(:new) { |**kwargs|
+      received_kwargs = kwargs
+      instance_double(EcsDeploy::Service, deploy: nil)
+    }
+
+    Rake::Task["ecs:deploy"].invoke
+
+    expect(received_kwargs[:cluster]).to eq("explicit-cluster")
+  end
+
+  it "filters services by TARGET_CLUSTER and compacts the result" do
+    Thread.current[:capistrano_settings][:ecs_services] = [
+      { name: "a", task_definition_name: "td", cluster: "keep" },
+      { name: "b", task_definition_name: "td", cluster: "drop" },
+    ]
+    Thread.current[:capistrano_settings][:target_cluster] = ["keep"]
+
+    invoked = []
+    allow(EcsDeploy::Service).to receive(:new) { |**kwargs|
+      invoked << kwargs[:service_name]
+      instance_double(EcsDeploy::Service, deploy: nil)
+    }
+    allow(EcsDeploy::Service).to receive(:wait_all_running) do |services|
+      expect(services).to all(be_a(RSpec::Mocks::InstanceVerifyingDouble))
+    end
+
+    Rake::Task["ecs:deploy"].invoke
+
+    expect(invoked).to eq(["a"])
+  end
+end


### PR DESCRIPTION
## Summary

`ecs:deploy` previously hand-listed each key it would forward from `set :ecs_services` entries to `EcsDeploy::Service.new`. Every time AWS added a new ECS service field, the gem had to be updated even though `EcsDeploy::Service` itself accepts `**options`. Forward the entire hash instead, with only three transforms:

- `:name` → `:service_name` (existing convention)
- `:cluster` defaults to `fetch(:ecs_default_cluster)`
- `:region` is injected from the current region iteration

New SDK fields like `deployment_controller`, `platform_version`, `service_connect_configuration`, `volume_configurations`, `availability_zone_rebalancing`, and `load_balancers[].advanced_configuration` now flow through without gem changes.

### Breaking change

Any custom non-SDK keys previously placed in `:ecs_services` entries were silently dropped; they will now reach the SDK and may raise. Users embedding internal metadata in the service hash should remove or rename those keys.

This is PR2 of the 4-PR stack for ECS-managed blue/green support. Follows #123.

## Test plan

- [x] `bundle exec rspec` — 40 examples, 0 failures (3 new in `spec/ecs_deploy/capistrano_spec.rb` exercising the rake task with a lightweight `fetch`/`set` stub since Capistrano is not a dev dependency)
- [x] Spec covers: full hash passthrough including unknown keys, `:name` → `:service_name` rename, `:cluster` fallback, `TARGET_CLUSTER` filter still compacts the result