### PR TITLE
Add ecs:{describe,continue,rollback,stop}_deployment tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New feature
+
+- Add `ecs:describe_deployment`, `ecs:continue_deployment[hook_id]`, `ecs:rollback_deployment[hook_id]`, `ecs:stop_deployment[service_deployment_arn]` capistrano tasks for operating ECS-managed blue/green deployments (lifecycle hook approval / rollback / abort).
+
 ### Breaking change
 
 - `ecs:deploy` capistrano task now passes the entire service hash through to `EcsDeploy::Service.new` instead of forwarding an explicit allow-list of keys. New SDK fields (e.g. `deployment_controller`, `platform_version`, `service_connect_configuration`, `volume_configurations`, `availability_zone_rebalancing`, `load_balancers[].advanced_configuration`) are supported automatically without gem updates. Any custom non-SDK keys previously placed in `set :ecs_services` entries will now reach the SDK and may cause errors — remove or rename them.
@@ -9,6 +13,7 @@
 ### Enhancement
 
 - Add `update_strategy: :task_definition_only` and `wait_strategy` options to `EcsDeploy::Service` for ECS-managed blue/green deployments (`DeploymentController.Type=ECS` with `BLUE_GREEN`/`LINEAR`/`CANARY`). `wait_all_running` now auto-detects ECS-managed deployments and skips polling so Capistrano sessions do not block on multi-day Pause Hooks.
+- Bump minimum `aws-sdk-ecs` to `1.238` for `continue_service_deployment`, `stop_service_deployment`, `LINEAR`/`CANARY` strategy, `lifecycle_hooks`, and `LoadBalancer.advanced_configuration`.
 
 # v1.0
 

--- a/ecs_deploy.gemspec
+++ b/ecs_deploy.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "aws-sdk-cloudwatch", "~> 1"
   spec.add_runtime_dependency "aws-sdk-cloudwatchevents", "~> 1"
   spec.add_runtime_dependency "aws-sdk-ec2", "~> 1"
-  spec.add_runtime_dependency "aws-sdk-ecs", "~> 1"
+  spec.add_runtime_dependency "aws-sdk-ecs", ">= 1.238", "< 2"
   spec.add_runtime_dependency "aws-sdk-sqs", "~> 1"
   spec.add_runtime_dependency "terminal-table"
   spec.add_runtime_dependency "paint"

--- a/lib/ecs_deploy.rb
+++ b/lib/ecs_deploy.rb
@@ -27,4 +27,5 @@ end
 
 require "ecs_deploy/task_definition"
 require "ecs_deploy/service"
+require "ecs_deploy/service_deployment"
 require "ecs_deploy/scheduled_task"

--- a/lib/ecs_deploy/capistrano.rb
+++ b/lib/ecs_deploy/capistrano.rb
@@ -110,6 +110,58 @@ namespace :ecs do
     end
   end
 
+  desc "Describe in-flight ECS service deployments for services in :ecs_services"
+  task describe_deployment: [:configure] do
+    if fetch(:ecs_services)
+      regions = Array(fetch(:ecs_region))
+      regions = [EcsDeploy.config.default_region] if regions.empty?
+      EcsDeploy::ServiceDeployment.describe(
+        services: fetch(:ecs_services),
+        regions: regions,
+        default_cluster: fetch(:ecs_default_cluster),
+      )
+    end
+  end
+
+  desc "Continue an ECS service deployment paused at a lifecycle hook"
+  task :continue_deployment, [:hook_id] => [:configure] do |_t, args|
+    raise "hook_id is required: cap ... ecs:continue_deployment[hook_id]" unless args[:hook_id]
+    regions = Array(fetch(:ecs_region))
+    regions = [EcsDeploy.config.default_region] if regions.empty?
+    EcsDeploy::ServiceDeployment.invoke_lifecycle_hook(
+      hook_id: args[:hook_id],
+      action: "CONTINUE",
+      services: fetch(:ecs_services),
+      regions: regions,
+      default_cluster: fetch(:ecs_default_cluster),
+    )
+  end
+
+  desc "Roll back an ECS service deployment paused at a lifecycle hook"
+  task :rollback_deployment, [:hook_id] => [:configure] do |_t, args|
+    raise "hook_id is required: cap ... ecs:rollback_deployment[hook_id]" unless args[:hook_id]
+    regions = Array(fetch(:ecs_region))
+    regions = [EcsDeploy.config.default_region] if regions.empty?
+    EcsDeploy::ServiceDeployment.invoke_lifecycle_hook(
+      hook_id: args[:hook_id],
+      action: "ROLLBACK",
+      services: fetch(:ecs_services),
+      regions: regions,
+      default_cluster: fetch(:ecs_default_cluster),
+    )
+  end
+
+  desc "Stop an in-progress ECS service deployment (STOP_TYPE env: ABORT or ROLLBACK)"
+  task :stop_deployment, [:service_deployment_arn] => [:configure] do |_t, args|
+    raise "service_deployment_arn is required: cap ... ecs:stop_deployment[arn]" unless args[:service_deployment_arn]
+    region = Array(fetch(:ecs_region)).first || EcsDeploy.config.default_region
+    EcsDeploy::ServiceDeployment.stop(
+      service_deployment_arn: args[:service_deployment_arn],
+      region: region,
+      stop_type: ENV["STOP_TYPE"],
+    )
+  end
+
   task rollback: [:configure] do
     if fetch(:ecs_services)
       regions = Array(fetch(:ecs_region))

--- a/lib/ecs_deploy/service_deployment.rb
+++ b/lib/ecs_deploy/service_deployment.rb
@@ -1,0 +1,71 @@
+module EcsDeploy
+  module ServiceDeployment
+    IN_FLIGHT_STATUSES = %w[IN_PROGRESS PENDING].freeze
+    DESCRIBE_STATUSES = %w[IN_PROGRESS PENDING STOPPED].freeze
+
+    class HookNotFoundError < StandardError; end
+
+    module_function
+
+    def describe(services:, regions:, default_cluster:)
+      each_target(services: services, regions: regions, default_cluster: default_cluster) do |client, cluster, svc|
+        deployments = list_deployments(client, cluster, svc[:name], statuses: DESCRIBE_STATUSES)
+        next if deployments.empty?
+        deployments.each { |d| log_deployment(d) }
+      end
+    end
+
+    def invoke_lifecycle_hook(hook_id:, action:, services:, regions:, default_cluster:)
+      found = false
+      each_target(services: services, regions: regions, default_cluster: default_cluster) do |client, cluster, svc|
+        deployments = list_deployments(client, cluster, svc[:name], statuses: IN_FLIGHT_STATUSES)
+        deployments.each do |d|
+          next unless Array(d.lifecycle_hook_details).any? { |h| h.hook_id == hook_id }
+          client.continue_service_deployment(
+            service_deployment_arn: d.service_deployment_arn,
+            hook_id: hook_id,
+            action: action,
+          )
+          EcsDeploy.logger.info "#{action.downcase}d lifecycle_hook=#{hook_id} service_deployment_arn=#{d.service_deployment_arn}"
+          found = true
+        end
+      end
+      raise HookNotFoundError, "Lifecycle hook #{hook_id} not found in any in-progress service deployment" unless found
+    end
+
+    def stop(service_deployment_arn:, region:, stop_type: nil)
+      client = Aws::ECS::Client.new(EcsDeploy.config.ecs_client_params.merge(region: region))
+      params = { service_deployment_arn: service_deployment_arn }
+      params[:stop_type] = stop_type if stop_type
+      client.stop_service_deployment(params)
+      EcsDeploy.logger.info "stopped service_deployment_arn=#{service_deployment_arn}#{stop_type ? " stop_type=#{stop_type}" : ""}"
+    end
+
+    def each_target(services:, regions:, default_cluster:)
+      services.each do |svc|
+        cluster = svc[:cluster] || default_cluster
+        regions.each do |r|
+          client = Aws::ECS::Client.new(EcsDeploy.config.ecs_client_params.merge(region: r))
+          yield client, cluster, svc
+        end
+      end
+    end
+
+    def list_deployments(client, cluster, service_name, statuses:)
+      arns = client.list_service_deployments(
+        cluster: cluster,
+        service: service_name,
+        status: statuses,
+      ).service_deployments.map(&:service_deployment_arn)
+      return [] if arns.empty?
+      client.describe_service_deployments(service_deployment_arns: arns).service_deployments
+    end
+
+    def log_deployment(d)
+      EcsDeploy.logger.info "service_deployment_arn=#{d.service_deployment_arn} status=#{d.status} lifecycle_stage=#{d.lifecycle_stage}"
+      Array(d.lifecycle_hook_details).each do |hook|
+        EcsDeploy.logger.info "  hook_id=#{hook.hook_id} target=#{hook.target_type} status=#{hook.status} expires_at=#{hook.expires_at} timeout_action=#{hook.timeout_action}"
+      end
+    end
+  end
+end

--- a/spec/ecs_deploy/service_deployment_spec.rb
+++ b/spec/ecs_deploy/service_deployment_spec.rb
@@ -1,0 +1,133 @@
+require "spec_helper"
+
+RSpec.describe EcsDeploy::ServiceDeployment do
+  let(:ecs_client) { Aws::ECS::Client.new(stub_responses: true, region: "us-east-1") }
+
+  before do
+    allow(Aws::ECS::Client).to receive(:new).and_return(ecs_client)
+  end
+
+  describe ".describe" do
+    it "lists and describes in-flight deployments and logs lifecycle hook details" do
+      ecs_client.stub_responses(:list_service_deployments, service_deployments: [
+        { service_deployment_arn: "arn:aws:ecs:::service-deployment/abc" },
+      ])
+      ecs_client.stub_responses(:describe_service_deployments, service_deployments: [
+        {
+          service_deployment_arn: "arn:aws:ecs:::service-deployment/abc",
+          status: "IN_PROGRESS",
+          lifecycle_stage: "POST_TEST_TRAFFIC_SHIFT",
+          lifecycle_hook_details: [
+            {
+              hook_id: "hook-1",
+              target_type: "PAUSE",
+              status: "PAUSED",
+              expires_at: Time.now + 3600,
+              timeout_action: "CONTINUE",
+            },
+          ],
+        },
+      ])
+
+      logdev = StringIO.new
+      EcsDeploy.instance_variable_set(:@logger, Logger.new(logdev))
+
+      described_class.describe(
+        services: [{ name: "svc1", cluster: "cluster1" }],
+        regions: ["us-east-1"],
+        default_cluster: "default-cluster",
+      )
+
+      log = logdev.string
+      expect(log).to include("service_deployment_arn=arn:aws:ecs:::service-deployment/abc")
+      expect(log).to include("hook_id=hook-1")
+      expect(log).to include("status=PAUSED")
+    end
+
+    it "is a no-op when there are no in-flight deployments" do
+      ecs_client.stub_responses(:list_service_deployments, service_deployments: [])
+
+      expect {
+        described_class.describe(
+          services: [{ name: "svc1", cluster: "cluster1" }],
+          regions: ["us-east-1"],
+          default_cluster: "default-cluster",
+        )
+      }.not_to raise_error
+
+      ops = ecs_client.api_requests.map { |r| r[:operation_name] }
+      expect(ops).to include(:list_service_deployments)
+      expect(ops).not_to include(:describe_service_deployments)
+    end
+  end
+
+  describe ".invoke_lifecycle_hook" do
+    before do
+      ecs_client.stub_responses(:list_service_deployments, service_deployments: [
+        { service_deployment_arn: "arn:aws:ecs:::service-deployment/abc" },
+      ])
+      ecs_client.stub_responses(:describe_service_deployments, service_deployments: [
+        {
+          service_deployment_arn: "arn:aws:ecs:::service-deployment/abc",
+          lifecycle_hook_details: [{ hook_id: "hook-1" }, { hook_id: "hook-2" }],
+        },
+      ])
+    end
+
+    it "calls continue_service_deployment with the matching deployment arn and action" do
+      described_class.invoke_lifecycle_hook(
+        hook_id: "hook-2",
+        action: "CONTINUE",
+        services: [{ name: "svc1" }],
+        regions: ["us-east-1"],
+        default_cluster: "c",
+      )
+
+      call = ecs_client.api_requests.find { |r| r[:operation_name] == :continue_service_deployment }
+      expect(call).not_to be_nil
+      expect(call[:params]).to eq(
+        service_deployment_arn: "arn:aws:ecs:::service-deployment/abc",
+        hook_id: "hook-2",
+        action: "CONTINUE",
+      )
+    end
+
+    it "raises when the hook is not found" do
+      expect {
+        described_class.invoke_lifecycle_hook(
+          hook_id: "missing",
+          action: "ROLLBACK",
+          services: [{ name: "svc1" }],
+          regions: ["us-east-1"],
+          default_cluster: "c",
+        )
+      }.to raise_error(EcsDeploy::ServiceDeployment::HookNotFoundError, /missing/)
+    end
+  end
+
+  describe ".stop" do
+    it "calls stop_service_deployment with the arn and stop_type when provided" do
+      described_class.stop(
+        service_deployment_arn: "arn:aws:ecs:::service-deployment/abc",
+        region: "us-east-1",
+        stop_type: "ABORT",
+      )
+
+      call = ecs_client.api_requests.find { |r| r[:operation_name] == :stop_service_deployment }
+      expect(call[:params]).to eq(
+        service_deployment_arn: "arn:aws:ecs:::service-deployment/abc",
+        stop_type: "ABORT",
+      )
+    end
+
+    it "omits stop_type when nil" do
+      described_class.stop(
+        service_deployment_arn: "arn:aws:ecs:::service-deployment/abc",
+        region: "us-east-1",
+      )
+
+      call = ecs_client.api_requests.find { |r| r[:operation_name] == :stop_service_deployment }
+      expect(call[:params]).to eq(service_deployment_arn: "arn:aws:ecs:::service-deployment/abc")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

ECS-managed blue/green deployments expose lifecycle hooks (PAUSE) and can be paused for hours or days waiting for human approval. Add four operational Capistrano tasks so operators can drive a deployment without dropping to raw `aws-sdk` calls.

- `ecs:describe_deployment` lists in-flight service deployments along with their lifecycle hook details (`hook_id`, `status`, `expires_at`, `timeout_action`) for every service in `:ecs_services`.
- `ecs:continue_deployment[hook_id]` and `ecs:rollback_deployment[hook_id]` approve or reject a paused lifecycle hook via `continue_service_deployment`. The hook is looked up by ID across services in `:ecs_services`; raises `EcsDeploy::ServiceDeployment::HookNotFoundError` when no match is found.
- `ecs:stop_deployment[arn]` stops an in-progress deployment via `stop_service_deployment`; `STOP_TYPE=ABORT|ROLLBACK` selects the stop type.

Shared logic lives in `EcsDeploy::ServiceDeployment` (new helper module) so the tasks stay short.

`aws-sdk-ecs` minimum is bumped to `1.238` — earlier versions are missing `continue_service_deployment`, `stop_service_deployment`, and the `lifecycle_hook_details` response field used by `ecs:describe_deployment`.

This is PR3 of the 4-PR stack for ECS-managed blue/green support. Follows #123, #124.

## Test plan

- [x] `bundle exec rspec` — 46 examples, 0 failures (6 new in `spec/ecs_deploy/service_deployment_spec.rb` covering describe / invoke_lifecycle_hook / stop)
- [x] Spec covers: stub-only describe of an in-progress deployment with one PAUSE hook detail, hook-id-based continue/rollback dispatch, `HookNotFoundError` when the hook id is missing, optional `stop_type` passthrough