### PR TITLE
docs: update changelog to reflect v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# v1.1
-
 ## Unreleased
+
+# v2.0.0 - 2026/07/02
 
 ### New feature
 


### PR DESCRIPTION
There should ideally be an entry for v2.1 as well, but I'm not entirely sure what changed in that version